### PR TITLE
feat: add autoware.repos

### DIFF
--- a/.github/workflows/vcs-import.yaml
+++ b/.github/workflows/vcs-import.yaml
@@ -1,0 +1,36 @@
+name: vcs-import
+
+on:
+  pull_request:
+    paths:
+      - autoware.repos
+  workflow_dispatch:
+
+jobs:
+  vcs-import:
+    runs-on: ubuntu-latest
+    container: ros:galactic
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Install pip for rosdep
+        run: |
+          sudo apt-get -y update
+          sudo apt-get -y install python3-pip
+
+      - name: Register AutonomouStuff repository
+        uses: autowarefoundation/autoware-github-actions/register-autonomoustuff-repository@tier4/proposal
+        with:
+          rosdistro: galactic
+
+      - name: Run vcs import
+        run: |
+          mkdir src
+          vcs import src < autoware.repos
+
+      - name: Run rosdep install
+        run: |
+          sudo apt-get -y update
+          rosdep update
+          DEBIAN_FRONTEND=noninteractive rosdep install -y --from-paths src --ignore-src --rosdistro galactic

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+# Vim
+*.swp
+*.swo
+
+# Visual Studio Code
+.vscode/
+*.code-workspace
+
+# colcon
+build/
+install/
+log/
+
+# Python
+*.pyc
+
+# Don't ignore src/ because full-text search won't work correctly.

--- a/README.md
+++ b/README.md
@@ -26,3 +26,17 @@ This is the list of the prototype repositories and their roles.
   - Since Autoware Core/Universe has multiple repositories, preparing a central documentation repository is more user-friendly than writing distributed documentation in each repository.
 
 If you have any questions or ideas, please feel free to start a discussion on [GitHub Discussions in autowarefoundation/autoware](https://github.com/autowarefoundation/autoware/discussions).
+
+---
+
+> Note: Detailed setup documents will be put into [autowarefoundation/autoware-documentation](https://github.com/autowarefoundation/autoware-documentation) soon.
+
+## How to setup workspace
+
+```bash
+mkdir src
+vcs import src < autoware.repos
+colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release
+source install/setup.bash
+ros2 launch tier4_autoware_launch planning_simulator.launch.xml vehicle_model:=lexus sensor_model:=aip_xx1 map_path:={path_to_your_map_dir}
+```

--- a/autoware.repos
+++ b/autoware.repos
@@ -1,0 +1,100 @@
+repositories:
+  # core
+  core/autoware_msgs:
+    type: git
+    url: https://github.com/tier4/autoware_auto_msgs.git # TODO(Tier IV): Move to autowarefoundation/autoware_msgs
+    version: tier4/main
+  core/common:
+    type: git
+    url: https://github.com/autowarefoundation/autoware_common.git
+    version: tier4/proposal
+  core/autoware:
+    type: git
+    url: https://github.com/autowarefoundation/autoware.core.git
+    version: tier4/proposal
+  # universe
+  universe/autoware:
+    type: git
+    url: https://github.com/autowarefoundation/autoware.universe.git
+    version: tier4/proposal
+  universe/tier4_autoware_msgs:
+    type: git
+    url: https://github.com/tier4/AutowareArchitectureProposal_msgs.git # TODO(Tier IV): Rename to tier4/tier4_autoware_msgs
+    version: tier4/universe
+  universe/vendor/grid_map:
+    type: git
+    url: https://github.com/ANYbotics/grid_map.git
+    version: ba2f9cb6e62f7ee9c5bac7401391a211e442e459
+  universe/vendor/mussp:
+    type: git
+    url: https://github.com/tier4/muSSP.git
+    version: tier4/main
+  universe/vendor/ndt_omp:
+    type: git
+    url: https://github.com/tier4/ndt_omp.git
+    version: tier4/main
+  universe/vendor/pointcloud_to_laserscan:
+    type: git
+    url: https://github.com/tier4/pointcloud_to_laserscan.git
+    version: tier4/main
+  universe/vendor/topic_tools:
+    type: git
+    url: https://github.com/tier4/topic_tools.git
+    version: tier4/main
+  # simulator
+  simulator/scenario_simulator:
+    type: git
+    url: https://github.com/tier4/scenario_simulator_v2.git
+    version: master
+  simulator/vendor/quaternion_operation:
+    type: git
+    url: https://github.com/OUXT-Polaris/quaternion_operation.git
+    version: f08cd28b357f9feede55f1fb485cb21964f5d594
+  simulator/tmp/tier4_autoware_msgs: # TODO(Tier IV): Remove depends from scenario_simulator
+    type: git
+    url: https://github.com/tier4/AutowareArchitectureProposal_msgs.git
+    version: main
+  simulator/tmp/api_adaptor: # TODO(Tier IV): Remove depends from scenario_simulator
+    type: git
+    url: https://github.com/tier4/AutowareArchitectureProposal_api_adaptor.git
+    version: tier4/universe
+  # sensor_component
+  sensor_component/tmp/velodyne_description: # TODO(Tier IV): Remove after https://github.com/ros/rosdistro/pull/31611 is released
+    type: git
+    url: https://github.com/tier4/velodyne_simulator.git
+    version: 7bca7039a1d9b0a37a268e7ced3e97b96fe9f5ee
+  sensor_component/sensor_component_description:
+    type: git
+    url: https://github.com/tier4/sensor_description.iv.git # TODO(Tier IV): Rename to tier4/sensor_component_description or so
+    version: main
+  sensor_component/livox-driver:
+    type: git
+    url: https://github.com/tier4/livox_ros2_driver.git
+    version: tier4/master
+  sensor_component/tamagawa_imu_driver:
+    type: git
+    url: https://github.com/tier4/tamagawa_imu_driver.git
+    version: ros2
+  sensor_component/velodyne_vls:
+    type: git
+    url: https://github.com/tier4/velodyne_vls.git
+    version: use-autoware-auto-msgs # TODO(Tier IV): Rename to tier4/universe or so
+  # sensor_kit
+  sensor_kit/tmp/tier4_sensor_kit_description:
+    type: git
+    url: https://github.com/tier4/aip_description.iv.git # TODO(Tier IV): Merge into tier4_sensor_kit_launch
+    version: main
+  sensor_kit/tier4_sensor_kit_launch:
+    type: git
+    url: https://github.com/tier4/AutowareArchitectureProposal_aip_launcher.git # TODO(Tier IV): Rename to tier4/tier4_sensor_kit_launch or so
+    version: use-autoware-auto-msgs # TODO(Tier IV): Rename to tier4/universe or so
+  # vehicle
+  vehicle/lexus_launch:
+    type: git
+    url: https://github.com/tier4/lexus_description.iv.git # TODO(Tier IV): Rename to lexus_launch
+    version: tier4/universe
+  # param
+  param/individual_vehicle_params:
+    type: git
+    url: https://github.com/tier4/autoware_individual_params.git # TODO(Tier IV): Copy to autowarefoundation/individual_vehicle_params or so and remove aip_* directory
+    version: main

--- a/autoware.repos
+++ b/autoware.repos
@@ -41,6 +41,10 @@ repositories:
     type: git
     url: https://github.com/tier4/topic_tools.git
     version: tier4/main
+  universe/vendor/pacmod3_msgs: # TODO(Tier IV): Remove after Galactic ARM version is released in https://s3.amazonaws.com/autonomoustuff-repo
+    type: git
+    url: https://github.com/astuff/pacmod3_msgs.git
+    version: main
   # sensor_component
   sensor_component/tmp/velodyne_description: # TODO(Tier IV): Remove after https://github.com/ros/rosdistro/pull/31611 is released
     type: git

--- a/autoware.repos
+++ b/autoware.repos
@@ -41,10 +41,6 @@ repositories:
     type: git
     url: https://github.com/tier4/topic_tools.git
     version: tier4/main
-  universe/vendor/pacmod3_msgs: # TODO(Tier IV): Remove after Galactic ARM version is released in https://s3.amazonaws.com/autonomoustuff-repo
-    type: git
-    url: https://github.com/astuff/pacmod3_msgs.git
-    version: main
   # sensor_component
   sensor_component/tmp/velodyne_description: # TODO(Tier IV): Remove after https://github.com/ros/rosdistro/pull/31611 is released
     type: git

--- a/autoware.repos
+++ b/autoware.repos
@@ -41,23 +41,6 @@ repositories:
     type: git
     url: https://github.com/tier4/topic_tools.git
     version: tier4/main
-  # simulator
-  simulator/scenario_simulator:
-    type: git
-    url: https://github.com/tier4/scenario_simulator_v2.git
-    version: master
-  simulator/vendor/quaternion_operation:
-    type: git
-    url: https://github.com/OUXT-Polaris/quaternion_operation.git
-    version: f08cd28b357f9feede55f1fb485cb21964f5d594
-  simulator/tmp/tier4_autoware_msgs: # TODO(Tier IV): Remove depends from scenario_simulator
-    type: git
-    url: https://github.com/tier4/AutowareArchitectureProposal_msgs.git
-    version: main
-  simulator/tmp/api_adaptor: # TODO(Tier IV): Remove depends from scenario_simulator
-    type: git
-    url: https://github.com/tier4/AutowareArchitectureProposal_api_adaptor.git
-    version: tier4/universe
   # sensor_component
   sensor_component/tmp/velodyne_description: # TODO(Tier IV): Remove after https://github.com/ros/rosdistro/pull/31611 is released
     type: git


### PR DESCRIPTION
Design concept:
- Only `autoware_msgs`, `autoware_common`, `autoware.core` are treated as Core.
  - They define interfaces (including libraries) of Autoware.
- Separate Core's dependencies(vendor) from Universe's ones.
  - It makes it easier to keep the `build_depends.repos`.
- Runtime dependencies are divided by their types, which helps people understand which parts they should customize.
  - sensor_component: Sensor components such as LiDAR, RADAR, camera, GNSS, etc.
  - sensor_kit: An assembly of sensor components.
  - vehicle: The vehicle type such as Lexus, JpnTaxi, etc.
  - param: Parameters for ODDs or each vehicle.