### PR TITLE
feat: split simulator repos file

### DIFF
--- a/autoware.repos
+++ b/autoware.repos
@@ -41,23 +41,6 @@ repositories:
     type: git
     url: https://github.com/tier4/topic_tools.git
     version: tier4/main
-  # # simulator
-  # simulator/scenario_simulator:
-  #   type: git
-  #   url: https://github.com/tier4/scenario_simulator_v2.git
-  #   version: master
-  # simulator/vendor/quaternion_operation:
-  #   type: git
-  #   url: https://github.com/OUXT-Polaris/quaternion_operation.git
-  #   version: f08cd28b357f9feede55f1fb485cb21964f5d594
-  # simulator/tmp/tier4_autoware_msgs: # TODO(Tier IV): Remove depends from scenario_simulator
-  #   type: git
-  #   url: https://github.com/tier4/AutowareArchitectureProposal_msgs.git
-  #   version: main
-  # simulator/tmp/api_adaptor: # TODO(Tier IV): Remove depends from scenario_simulator
-  #   type: git
-  #   url: https://github.com/tier4/AutowareArchitectureProposal_api_adaptor.git
-  #   version: tier4/universe
   # sensor_component
   sensor_component/tmp/velodyne_description: # TODO(Tier IV): Remove after https://github.com/ros/rosdistro/pull/31611 is released
     type: git

--- a/simulator.repos
+++ b/simulator.repos
@@ -1,0 +1,17 @@
+repositories:
+  simulator/scenario_simulator:
+    type: git
+    url: https://github.com/tier4/scenario_simulator_v2.git
+    version: master
+  simulator/vendor/quaternion_operation:
+    type: git
+    url: https://github.com/OUXT-Polaris/quaternion_operation.git
+    version: f08cd28b357f9feede55f1fb485cb21964f5d594
+  simulator/tmp/tier4_autoware_msgs: # TODO(Tier IV): Remove depends from scenario_simulator
+    type: git
+    url: https://github.com/tier4/AutowareArchitectureProposal_msgs.git
+    version: main
+  simulator/tmp/api_adaptor: # TODO(Tier IV): Remove depends from scenario_simulator
+    type: git
+    url: https://github.com/tier4/AutowareArchitectureProposal_api_adaptor.git
+    version: tier4/universe


### PR DESCRIPTION
In order to avoid the errors such as autowarefoundation/autoware.ai#2413, I'd like to split `.repos` file for simulators.
This is a tentative approach and we should discuss what is the best way to manage `.repos` files.