### PR TITLE
ci(pre-commit-optional): fix args of markdown-link-check

### DIFF
--- a/.pre-commit-config-optional.yaml
+++ b/.pre-commit-config-optional.yaml
@@ -3,3 +3,4 @@ repos:
     rev: v3.9.2
     hooks:
       - id: markdown-link-check
+        args: [--config=.markdown-link-check.json]


### PR DESCRIPTION
As we changed the pre-commit hook from [this](https://github.com/ComPWA/mirrors-markdown-link-check/blob/b0fa1e66dcfc02d52d17344da74bfb39342054b0/.pre-commit-hooks.yaml#L3) to [this](https://github.com/tcort/markdown-link-check/blob/c264852c374f14c7bb40c7bed7b61791c4107049/.pre-commit-hooks.yaml), we had to specify the path to the config file.