### PR TITLE
ci(pre-commit-optional): update markdown-link-check config

### DIFF
--- a/.markdown-link-check.json
+++ b/.markdown-link-check.json
@@ -1,6 +1,10 @@
 {
   "aliveStatusCodes": [200, 206, 403],
-  "ignorePatterns": [],
+  "ignorePatterns": [
+    {
+      "pattern": "^http://localhost"
+    }
+  ],
   "retryOn429": true,
   "retryCount": 10
 }

--- a/.pre-commit-config-optional.yaml
+++ b/.pre-commit-config-optional.yaml
@@ -1,5 +1,5 @@
 repos:
   - repo: https://github.com/tcort/markdown-link-check
-    rev: v3.9.2
+    rev: v3.9.3
     hooks:
       - id: markdown-link-check


### PR DESCRIPTION
I'll merge this after https://github.com/tcort/markdown-link-check/pull/184 is merged and released as `v3.9.3`.