### PR TITLE
chore: add yamllint rules for braces

### DIFF
--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -7,7 +7,7 @@ ignore: |
 rules:
   braces:
     level: error
-    max-spaces-inside: 1
+    max-spaces-inside: 1 # To autoformat with Prettier
   comments:
     level: error
     min-spaces-from-content: 1 # To be compatible with C++ and Python

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -8,9 +8,6 @@ rules:
   braces:
     level: error
     max-spaces-inside: 1
-  brackets:
-    level: error
-    max-spaces-inside: 1
   comments:
     level: error
     min-spaces-from-content: 1 # To be compatible with C++ and Python

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -7,7 +7,7 @@ ignore: |
 rules:
   braces:
     level: error
-    max-spaces-inside: 1 # To autoformat with Prettier
+    max-spaces-inside: 1 # To format with Prettier
   comments:
     level: error
     min-spaces-from-content: 1 # To be compatible with C++ and Python

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -5,6 +5,12 @@ ignore: |
   *.param.yaml
 
 rules:
+  braces:
+    level: error
+    max-spaces-inside: 1
+  brackets:
+    level: error
+    max-spaces-inside: 1
   comments:
     level: error
     min-spaces-from-content: 1 # To be compatible with C++ and Python


### PR DESCRIPTION
according to https://prettier.io/docs/en/options.html#bracket-spacing, Prettier has the bracket rule and printing spaces between brackets is default.
So, This PR adds some yamllint rules which define max spaces inside brackets and braces .