### PR TITLE
ci: split ARM workflow

### DIFF
--- a/.github/workflows/build-arm.yaml
+++ b/.github/workflows/build-arm.yaml
@@ -1,4 +1,4 @@
-name: build
+name: build-arm
 
 on:
   schedule:
@@ -6,8 +6,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
+  build-arm:
+    runs-on: [self-hosted, linux, ARM64]
     container: ubuntu:20.04
     steps:
       - name: Check out repository


### PR DESCRIPTION
Considering the forks, since they usually cannot run self-hosted runners, I'll split workflows of `amd64` and `arm64`.