### PR TITLE
feat: install NVIDIA Container Toolkit

### DIFF
--- a/ansible/roles/docker/README.md
+++ b/ansible/roles/docker/README.md
@@ -2,7 +2,11 @@
 
 This role installs Docker environment following [this page](https://docs.docker.com/engine/install/ubuntu/) and sets up rootless execution following [this page](https://docs.docker.com/engine/install/linux-postinstall/).
 
-Also, it installs [rocker](https://github.com/osrf/rocker) for easy NVIDIA support.
+Also, it installs some additional tools:
+
+- [Docker Compose](https://github.com/docker/compose)
+- [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html#docker)
+- [rocker](https://github.com/osrf/rocker)
 
 ## Inputs
 

--- a/ansible/roles/docker/tasks/main.yaml
+++ b/ansible/roles/docker/tasks/main.yaml
@@ -70,6 +70,39 @@
     groups: docker
     append: true
 
+- name: Save result of '. /etc/os-release;echo $ID$VERSION_ID'
+  ansible.builtin.shell: . /etc/os-release;echo $ID$VERSION_ID
+  register: distribution
+  changed_when: false
+
+- name: Authorize NVIDIA Docker GPG key
+  become: true
+  ansible.builtin.apt_key:
+    url: https://nvidia.github.io/nvidia-docker/gpgkey
+
+- name: Save result of 'curl -s -L https://nvidia.github.io/nvidia-docker/$distribution/nvidia-docker.list'
+  ansible.builtin.command: curl -s -L https://nvidia.github.io/nvidia-docker/{{ distribution.stdout }}/nvidia-docker.list
+  register: nvidia_docker_list
+  changed_when: false
+
+# curl -s -L https://nvidia.github.io/nvidia-docker/$distribution/nvidia-docker.list | sudo tee /etc/apt/sources.list.d/nvidia-docker.list
+- name: Add NVIDIA Docker apt repository to source list
+  become: true
+  ansible.builtin.lineinfile:
+    dest: /etc/apt/sources.list.d/nvidia-docker.list
+    line: "{{ item }}"
+    state: present
+    create: true
+    mode: 0644
+  with_items: "{{ nvidia_docker_list.stdout_lines }}"
+
+- name: Install NVIDIA Container Toolkit
+  become: true
+  ansible.builtin.apt:
+    name:
+      - nvidia-docker2
+    update_cache: true
+
 - name: Install Docker Compose
   become: true
   ansible.builtin.get_url:

--- a/ansible/roles/docker/tasks/main.yaml
+++ b/ansible/roles/docker/tasks/main.yaml
@@ -81,9 +81,10 @@
     url: https://nvidia.github.io/nvidia-docker/gpgkey
 
 - name: Save result of 'curl -s -L https://nvidia.github.io/nvidia-docker/$distribution/nvidia-docker.list'
-  ansible.builtin.command: curl -s -L https://nvidia.github.io/nvidia-docker/{{ distribution.stdout }}/nvidia-docker.list
+  ansible.builtin.uri:
+    url: https://nvidia.github.io/nvidia-docker/{{ distribution.stdout }}/nvidia-docker.list
+    return_content: true
   register: nvidia_docker_list
-  changed_when: false
 
 # curl -s -L https://nvidia.github.io/nvidia-docker/$distribution/nvidia-docker.list | sudo tee /etc/apt/sources.list.d/nvidia-docker.list
 - name: Add NVIDIA Docker apt repository to source list
@@ -94,7 +95,7 @@
     state: present
     create: true
     mode: 0644
-  with_items: "{{ nvidia_docker_list.stdout_lines }}"
+  with_items: "{{ nvidia_docker_list.content }}"
 
 - name: Install NVIDIA Container Toolkit
   become: true


### PR DESCRIPTION
I had to install [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html#docker) for runtime.