### PR TITLE
style(ansible_lint): fix lint errors

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -4,3 +4,5 @@ exclude_paths:
 skip_list:
   - meta-no-info # We don't publish to Ansible Galaxy.
   - package-latest # Since this is a development environment, we allow the latest versions.
+
+warn_list: []

--- a/ansible/roles/cuda/tasks/main.yaml
+++ b/ansible/roles/cuda/tasks/main.yaml
@@ -37,6 +37,7 @@
     line: export PATH="/usr/local/cuda/bin:$PATH"
     state: present
     create: true
+    mode: 0644
 
 - name: Add LD_LIBRARY_PATH to bashrc
   ansible.builtin.lineinfile:
@@ -44,3 +45,4 @@
     line: export LD_LIBRARY_PATH="/usr/local/cuda/lib64:$LD_LIBRARY_PATH"
     state: present
     create: true
+    mode: 0644

--- a/ansible/roles/rmw_implementation/tasks/main.yaml
+++ b/ansible/roles/rmw_implementation/tasks/main.yaml
@@ -16,3 +16,4 @@
     line: export RMW_IMPLEMENTATION={{ rmw_implementation }}
     state: present
     create: true
+    mode: 0644

--- a/ansible/roles/ros2/tasks/main.yaml
+++ b/ansible/roles/ros2/tasks/main.yaml
@@ -46,3 +46,4 @@
     line: source /opt/ros/{{ rosdistro }}/setup.bash
     state: present
     create: true
+    mode: 0644


### PR DESCRIPTION
`risky-file-permissions` was overlooked because it was marked as experimental.
https://github.com/autowarefoundation/autoware/runs/5052416636?check_suite_focus=true