### PR TITLE
feat(ansible): install python3-colcon-mixin in ros2_dev_tools

### DIFF
--- a/ansible/roles/ros2_dev_tools/tasks/main.yaml
+++ b/ansible/roles/ros2_dev_tools/tasks/main.yaml
@@ -6,6 +6,7 @@
       - cmake
       - git
       - python3-colcon-common-extensions
+      - python3-colcon-mixin
       - python3-flake8
       - python3-pip
       - python3-pytest-cov


### PR DESCRIPTION
Added colcon-mixin to ros2_dev_tools in ansible playbook.

Signed-off-by: Keisuke Shima <19993104+KeisukeShima@users.noreply.github.com>