### PR TITLE
chore: split pre-commit of ansible-lint

### DIFF
--- a/.github/workflows/pre-commit-ansible.yaml
+++ b/.github/workflows/pre-commit-ansible.yaml
@@ -1,0 +1,20 @@
+name: pre-commit-ansible
+
+on:
+  pull_request:
+
+jobs:
+  pre-commit-ansible:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v2
+
+      - name: Install Ansible Galaxy depends for ansible-lint
+        run: |
+          ansible-galaxy collection install -f -r ansible-galaxy-requirements.yaml
+
+      - name: Run pre-commit
+        uses: autowarefoundation/autoware-github-actions/pre-commit@tier4/proposal
+        with:
+          pre-commit-config: .pre-commit-config-ansible.yaml

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -10,11 +10,6 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v2
 
-      # This can be removed if we'll manage ansible files in another repository.
-      - name: Install Ansible Galaxy depends for ansible-lint
-        run: |
-          ansible-galaxy collection install -f -r ansible-galaxy-requirements.yaml
-
       - name: Run pre-commit
         uses: autowarefoundation/autoware-github-actions/pre-commit@tier4/proposal
         with:

--- a/.pre-commit-config-ansible.yaml
+++ b/.pre-commit-config-ansible.yaml
@@ -1,0 +1,5 @@
+repos:
+  - repo: https://github.com/ansible/ansible-lint.git
+    rev: v5.3.2
+    hooks:
+      - id: ansible-lint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,8 +1,6 @@
 ci:
   autofix_commit_msg: "ci(pre-commit): autofix"
   autoupdate_commit_msg: "ci(pre-commit): autoupdate"
-  skip:
-    - ansible-lint # https://github.com/pre-commit-ci/issues/issues/42
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -34,11 +32,6 @@ repos:
     rev: v1.26.3
     hooks:
       - id: yamllint
-
-  - repo: https://github.com/ansible/ansible-lint.git
-    rev: v5.3.2
-    hooks:
-      - id: ansible-lint
 
   - repo: https://github.com/shellcheck-py/shellcheck-py
     rev: v0.8.0.3


### PR DESCRIPTION
To reuse `pre-commit.yaml` in many repositories.