### PR TITLE
chore: add issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yaml
+++ b/.github/ISSUE_TEMPLATE/bug.yaml
@@ -1,0 +1,71 @@
+name: Bug
+description: Report a bug
+body:
+  - type: checkboxes
+    attributes:
+      label: Checklist
+      description: Confirm the following items before proceeding. If one cannot be satisfied, create a discussion thread instead.
+      options:
+        - label: I've read the [contribution guidelines](https://github.com/autowarefoundation/autoware/blob/main/CONTRIBUTING.md).
+          required: true
+        - label: I've searched other issues and no duplicate issues were found.
+          required: true
+        - label: I'm convinced that this is not my fault but a bug.
+          required: true
+
+  - type: textarea
+    attributes:
+      label: Description
+      description: Write a brief description of the bug.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Expected behavior
+      description: Describe the expected behavior.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Actual behavior
+      description: Describe the actual behavior.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Steps to reproduce
+      description: Write the steps to reproduce the bug.
+      placeholder: |-
+        1.
+        2.
+        3.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Versions
+      description: Provide the version information. You can omit this if you believe it's irrelevant.
+      placeholder: |-
+        - OS:
+        - ROS 2:
+        - Autoware:
+    validations:
+      required: false
+
+  - type: textarea
+    attributes:
+      label: Possible causes
+      description: Write the possible causes if you have any ideas.
+    validations:
+      required: false
+
+  - type: textarea
+    attributes:
+      label: Additional context
+      description: Add any other additional context if it exists.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,13 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Question
+    url: https://github.com/autowarefoundation/autoware/discussions/new?category=q-a
+    about: Ask a question
+
+  - name: Idea
+    url: https://github.com/autowarefoundation/autoware/discussions/new?category=ideas
+    about: Post an idea
+
+  - name: Request
+    url: https://github.com/autowarefoundation/autoware/discussions/new?category=requests
+    about: Send a request

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,10 +4,10 @@ contact_links:
     url: https://github.com/autowarefoundation/autoware/discussions/new?category=q-a
     about: Ask a question
 
+  - name: Feature request
+    url: https://github.com/autowarefoundation/autoware/discussions/new?category=feature-requests
+    about: Send a feature request
+
   - name: Idea
     url: https://github.com/autowarefoundation/autoware/discussions/new?category=ideas
     about: Post an idea
-
-  - name: Request
-    url: https://github.com/autowarefoundation/autoware/discussions/new?category=requests
-    about: Send a request

--- a/.github/ISSUE_TEMPLATE/task.yaml
+++ b/.github/ISSUE_TEMPLATE/task.yaml
@@ -1,0 +1,42 @@
+name: Task
+description: Plan a task
+body:
+  - type: checkboxes
+    attributes:
+      label: Checklist
+      description: Confirm the following items before proceeding. If one cannot be satisfied, create a discussion thread instead.
+      options:
+        - label: I've read the [contribution guidelines](https://github.com/autowarefoundation/autoware/blob/main/CONTRIBUTING.md).
+          required: true
+        - label: I've searched other issues and no duplicate issues were found.
+          required: true
+        - label: I've agreed with the maintainers that I can plan this task.
+          required: true
+
+  - type: textarea
+    attributes:
+      label: Description
+      description: Write a brief description of the task.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Purpose
+      description: Describe the purpose of the task.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Possible approaches
+      description: Describe possible approaches for the task.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Definition of done
+      description: Write the definition of done for the task.
+    validations:
+      required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,4 @@
+Click the `Preview` tab and select a PR template:
+
+- [Standard change](?expand=1&template=standard-change.md)
+- [Small change](?expand=1&template=small-change.md)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,5 @@
+**Note**: Confirm our [contribution guidelines](https://autowarefoundation.github.io/autoware-documentation/main/contributing/) before submitting a pull request.
+
 Click the `Preview` tab and select a PR template:
 
 - [Standard change](?expand=1&template=standard-change.md)

--- a/.github/PULL_REQUEST_TEMPLATE/small-change.md
+++ b/.github/PULL_REQUEST_TEMPLATE/small-change.md
@@ -1,0 +1,27 @@
+## Description
+
+<!-- Write a brief description of this PR. -->
+
+## Pre-review checklist for the PR author
+
+PR author **must** check the checkboxes below when creating the PR.
+
+- [ ] I've confirmed the [contribution guidelines].
+- [ ] The PR follows the [pull request guidelines].
+
+## In-review checklist for the PR reviewers
+
+Reviewers **must** check the checkboxes below before approval.
+
+- [ ] The PR follows the [pull request guidelines].
+
+## Post-review checklist for the PR author
+
+PR author **must** check the checkboxes below before merging.
+
+- [ ] There are no open points or they are tracked via tickets.
+
+After all checkboxes are checked, anyone who has the write access can merge the PR.
+
+[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
+[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/

--- a/.github/PULL_REQUEST_TEMPLATE/small-change.md
+++ b/.github/PULL_REQUEST_TEMPLATE/small-change.md
@@ -19,7 +19,7 @@ Reviewers **must** check the checkboxes below before approval.
 
 PR author **must** check the checkboxes below before merging.
 
-- [ ] There are no open points or they are tracked via tickets.
+- [ ] There are no open discussions or they are tracked via tickets.
 
 After all checkboxes are checked, anyone who has the write access can merge the PR.
 

--- a/.github/PULL_REQUEST_TEMPLATE/standard-change.md
+++ b/.github/PULL_REQUEST_TEMPLATE/standard-change.md
@@ -1,0 +1,42 @@
+## Description
+
+<!-- Write a brief description of this PR. -->
+
+## Related links
+
+<!-- Write the links related to this PR. -->
+
+## Tests performed
+
+<!-- Describe how you have tested this PR. -->
+
+## Notes for reviewers
+
+<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->
+
+## Pre-review checklist for the PR author
+
+PR author **must** check the checkboxes below when creating the PR.
+
+- [ ] I've confirmed the [contribution guidelines].
+- [ ] The PR follows the [pull request guidelines].
+
+## In-review checklist for the PR reviewers
+
+Reviewers **must** check the checkboxes below before approval.
+
+- [ ] The PR follows the [pull request guidelines].
+- [ ] The PR has been properly tested.
+- [ ] The PR has been reviewed by the code owners.
+
+## Post-review checklist for the PR author
+
+PR author **must** check the checkboxes below before merging.
+
+- [ ] There are no open points or they are tracked via tickets.
+- [ ] The PR is ready for merge.
+
+After all checkboxes are checked, anyone who has the write access can merge the PR.
+
+[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
+[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/

--- a/.github/PULL_REQUEST_TEMPLATE/standard-change.md
+++ b/.github/PULL_REQUEST_TEMPLATE/standard-change.md
@@ -33,7 +33,7 @@ Reviewers **must** check the checkboxes below before approval.
 
 PR author **must** check the checkboxes below before merging.
 
-- [ ] There are no open points or they are tracked via tickets.
+- [ ] There are no open discussions or they are tracked via tickets.
 - [ ] The PR is ready for merge.
 
 After all checkboxes are checked, anyone who has the write access can merge the PR.


### PR DESCRIPTION
Added templates.
Please refer to https://github.com/kenji-miyake/test-pr-template about its behavior.

References:
- https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms
- https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository