### PR TITLE
fix: `scenario_simulator_v2` dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ Suppose that you've installed a development environment.
    ```bash
    mkdir src
    vcs import src < autoware.repos
+   vcs import src < simulator.repos # Optional: If you want to run scenario simulation with tier4/scenario_simulator_v2, execute this line.
    ```
 
 2. Install dependent ROS packages.
@@ -140,6 +141,20 @@ Suppose that you've set up a workspace.
    ```bash
    source install/setup.bash
    ros2 launch tier4_autoware_launch planning_simulator.launch.xml vehicle_model:=lexus sensor_model:=aip_xx1 map_path:=$HOME/Downloads/sample_map
+   ```
+
+### How to run a scenario simulation
+
+1. Launch a simulation.
+
+   ```bash
+   ros2 launch scenario_test_runner scenario_test_runner.launch.py \
+     autoware_launch_package:=tier4_autoware_launch \
+     initialize_duration:=20 \
+     record:=false \
+     scenario:='$(find-pkg-share scenario_test_runner)/test/scenario/autoware-simple.yaml' \
+     sensor_model:=aip_xx1 \
+     vehicle_model:=lexus
    ```
 
 > Note: More tutorials will be written [here](https://autowarefoundation.github.io/autoware-documentation/tier4-proposal/) soon.

--- a/README.md
+++ b/README.md
@@ -107,7 +107,6 @@ Suppose that you've installed a development environment.
    ```bash
    mkdir src
    vcs import src < autoware.repos
-   vcs import src < simulator.repos # Optional: If you want to run scenario simulation with tier4/scenario_simulator_v2, execute this line.
    ```
 
 2. Install dependent ROS packages.
@@ -141,20 +140,6 @@ Suppose that you've set up a workspace.
    ```bash
    source install/setup.bash
    ros2 launch tier4_autoware_launch planning_simulator.launch.xml vehicle_model:=lexus sensor_model:=aip_xx1 map_path:=$HOME/Downloads/sample_map
-   ```
-
-### How to run a scenario simulation
-
-1. Launch a simulation.
-
-   ```bash
-   ros2 launch scenario_test_runner scenario_test_runner.launch.py \
-     autoware_launch_package:=tier4_autoware_launch \
-     initialize_duration:=20 \
-     record:=false \
-     scenario:='$(find-pkg-share scenario_test_runner)/test/scenario/autoware-simple.yaml' \
-     sensor_model:=aip_xx1 \
-     vehicle_model:=lexus
    ```
 
 > Note: More tutorials will be written [here](https://autowarefoundation.github.io/autoware-documentation/tier4-proposal/) soon.

--- a/simulator.repos
+++ b/simulator.repos
@@ -2,7 +2,7 @@ repositories:
   simulator/scenario_simulator:
     type: git
     url: https://github.com/tier4/scenario_simulator_v2.git
-    version: feature/autoware-external-api
+    version: master
   simulator/vendor/quaternion_operation:
     type: git
     url: https://github.com/OUXT-Polaris/quaternion_operation.git

--- a/simulator.repos
+++ b/simulator.repos
@@ -2,16 +2,8 @@ repositories:
   simulator/scenario_simulator:
     type: git
     url: https://github.com/tier4/scenario_simulator_v2.git
-    version: master
+    version: feature/autoware-external-api
   simulator/vendor/quaternion_operation:
     type: git
     url: https://github.com/OUXT-Polaris/quaternion_operation.git
-    version: f08cd28b357f9feede55f1fb485cb21964f5d594
-  simulator/tmp/tier4_autoware_msgs: # TODO(Tier IV): Remove depends from scenario_simulator
-    type: git
-    url: https://github.com/tier4/AutowareArchitectureProposal_msgs.git
-    version: main
-  simulator/tmp/api_adaptor: # TODO(Tier IV): Remove depends from scenario_simulator
-    type: git
-    url: https://github.com/tier4/AutowareArchitectureProposal_api_adaptor.git
-    version: tier4/universe
+    version: ros2


### PR DESCRIPTION
Since scenario_simulator_v2 now supports Autoware.Universe, I've organized the dependent packages so that this repository can build and run scenario_simulator_v2 correctly.