### PR TITLE
feat: add autoware_launch to autoware.repos

### DIFF
--- a/autoware.repos
+++ b/autoware.repos
@@ -41,6 +41,11 @@ repositories:
     type: git
     url: https://github.com/tier4/topic_tools.git
     version: tier4/main
+  # launcher
+  launcher/autoware_launch:
+    type: git
+    url: https://github.com/autowarefoundation/autoware_launch.git
+    version: main
   # sensor_component
   sensor_component/sensor_component_description:
     type: git


### PR DESCRIPTION
While I'm writing this tutorial https://github.com/autowarefoundation/autoware-documentation/pull/28, I found that we have to run Autoware by `ros2 launch tier4_autoware_launch`.

However, it's not a good interface because the CLI interface will change depending on the launch package.
It's useful if all users can use the same interface `ros2 launch autoware_launch`.

The followings are the images of the As-is and the To-be state.

As-is: We can't use the same package name, so the CLI interface will change.

```mermaid
graph TD
    User -->|ros2 launch another_autoware_launch| another_autoware_launch
    User -->|ros2 launch tier4_autoware_launch| tier4_autoware_launch

    another_autoware_launch --> company_A_sensing_launch_1
    another_autoware_launch --> company_B_perception_launch_1
    another_autoware_launch --> company_C_planning_launch_1

    tier4_autoware_launch --> tier4_sensing_launch
    tier4_autoware_launch --> tier4_perception_launch
    tier4_autoware_launch --> company_C_planning_launch_1

    subgraph autowarefoundation/autoware.universe
        another_autoware_launch
        tier4_autoware_launch
        company_A_sensing_launch_1
        company_B_perception_launch_1
        company_C_planning_launch_1
    end

    subgraph tier4/tier4_sensor_kit_launch
        tier4_sensing_launch
        tier4_perception_launch
    end
```

Note: We can't use the name autoware_launch here because the package names will conflict.

To-be: We can use the same package name, so we can use the same CLI interface.

```mermaid
graph TD
    User -->|ros2 launch autoware_launch| autoware_launch_1
    User -->|ros2 launch autoware_launch| autoware_launch_2

    autoware_launch_1 --> company_A_sensing_launch_1
    autoware_launch_1 --> company_B_perception_launch_1
    autoware_launch_1 --> company_C_planning_launch_1

    autoware_launch_2 --> tier4_sensing_launch
    autoware_launch_2 --> tier4_perception_launch
    autoware_launch_2 --> company_C_planning_launch_1

    subgraph autowarefoundation/autoware_launch
        autoware_launch_1
    end

    subgraph tier4/autoware_launch
        autoware_launch_2
    end


    subgraph autowarefoundation/autoware.universe
        company_A_sensing_launch_1
        company_B_perception_launch_1
        company_C_planning_launch_1
    end

    subgraph tier4/tier4_sensor_kit_launch
        tier4_sensing_launch
        tier4_perception_launch
    end
```

Therefore, I'd like to add the autoware_launch repository to `autoware.repos`.
We can switch the implementation of autoware_launch by changing the reference in `autoware.repos`.

Note: Of course, if users want to use a name other than `autoware_launch`, they can use it. This PR will just add an option for users.