### PR TITLE
fix: use autowarefoundation/autoware_individual_params

### DIFF
--- a/autoware.repos
+++ b/autoware.repos
@@ -78,7 +78,7 @@ repositories:
     url: https://github.com/tier4/pacmod_interface.git
     version: main
   # param
-  param/individual_vehicle_params:
+  param/individual_params:
     type: git
-    url: https://github.com/tier4/autoware_individual_params.git # TODO(Tier IV): Copy to autowarefoundation/individual_vehicle_params or so and remove aip_* directory
+    url: https://github.com/autowarefoundation/autoware_individual_params.git
     version: main


### PR DESCRIPTION
This repository is used to store parameters that change depending on each vehicle, for example, sensor calibration parameters, hardware IDs, etc.

I'll consider renaming the repository name and the package name in the future.