### PR TITLE
chore: remove TODO comment in CPPLINT.cfg

### DIFF
--- a/CPPLINT.cfg
+++ b/CPPLINT.cfg
@@ -9,5 +9,5 @@ filter=-whitespace/braces         # we wrap open curly braces for namespaces, cl
 filter=-whitespace/indent         # we don't indent keywords like public, protected and private with one space
 filter=-whitespace/parens         # we allow closing parenthesis to be on the next line
 filter=-whitespace/semicolon      # we allow the developer to decide about whitespace after a semicolon
-filter=-build/header_guard        # TODO(Kenji Miyake): Support ROS-style rule in cpplint or add auto-fix script in pre-commit
+filter=-build/header_guard        # we automatically fix the names of header guards using pre-commit
 filter=-build/include_order       # we use the custom include order


### PR DESCRIPTION
A `pre-commit` hook is introduced by @isamu-takagi in https://github.com/autowarefoundation/autoware.universe/pull/438.