### PR TITLE
feat(autoware.repos): refer to main branch instead of tier4/proposal

### DIFF
--- a/.github/workflows/pre-commit-ansible.yaml
+++ b/.github/workflows/pre-commit-ansible.yaml
@@ -15,6 +15,6 @@ jobs:
           ansible-galaxy collection install -f -r ansible-galaxy-requirements.yaml
 
       - name: Run pre-commit
-        uses: autowarefoundation/autoware-github-actions/pre-commit@tier4/proposal
+        uses: autowarefoundation/autoware-github-actions/pre-commit@v1
         with:
           pre-commit-config: .pre-commit-config-ansible.yaml

--- a/.github/workflows/pre-commit-optional.yaml
+++ b/.github/workflows/pre-commit-optional.yaml
@@ -11,6 +11,6 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Run pre-commit
-        uses: autowarefoundation/autoware-github-actions/pre-commit@tier4/proposal
+        uses: autowarefoundation/autoware-github-actions/pre-commit@v1
         with:
           pre-commit-config: .pre-commit-config-optional.yaml

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -11,6 +11,6 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Run pre-commit
-        uses: autowarefoundation/autoware-github-actions/pre-commit@tier4/proposal
+        uses: autowarefoundation/autoware-github-actions/pre-commit@v1
         with:
           pre-commit-config: .pre-commit-config.yaml

--- a/.github/workflows/semantic-pull-request.yaml
+++ b/.github/workflows/semantic-pull-request.yaml
@@ -9,4 +9,4 @@ on:
 
 jobs:
   semantic-pull-request:
-    uses: autowarefoundation/autoware-github-actions/.github/workflows/semantic-pull-request.yaml@tier4/proposal
+    uses: autowarefoundation/autoware-github-actions/.github/workflows/semantic-pull-request.yaml@v1

--- a/.github/workflows/spell-check-differential.yaml
+++ b/.github/workflows/spell-check-differential.yaml
@@ -11,6 +11,6 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Run spell-check
-        uses: autowarefoundation/autoware-github-actions/spell-check@tier4/proposal
+        uses: autowarefoundation/autoware-github-actions/spell-check@v1
         with:
           cspell-json-url: https://raw.githubusercontent.com/tier4/autoware-spell-check-dict/main/.cspell.json

--- a/.github/workflows/vcs-import.yaml
+++ b/.github/workflows/vcs-import.yaml
@@ -18,7 +18,7 @@ jobs:
           sudo apt-get -y install python3-pip
 
       - name: Register AutonomouStuff repository
-        uses: autowarefoundation/autoware-github-actions/register-autonomoustuff-repository@tier4/proposal
+        uses: autowarefoundation/autoware-github-actions/register-autonomoustuff-repository@v1
         with:
           rosdistro: galactic
 

--- a/autoware.repos
+++ b/autoware.repos
@@ -7,16 +7,16 @@ repositories:
   core/common:
     type: git
     url: https://github.com/autowarefoundation/autoware_common.git
-    version: tier4/proposal
+    version: main
   core/autoware:
     type: git
     url: https://github.com/autowarefoundation/autoware.core.git
-    version: tier4/proposal
+    version: main
   # universe
   universe/autoware:
     type: git
     url: https://github.com/autowarefoundation/autoware.universe.git
-    version: tier4/proposal
+    version: main
   universe/tier4_autoware_msgs:
     type: git
     url: https://github.com/tier4/tier4_autoware_msgs.git


### PR DESCRIPTION
Use `main` or `v1` instead of `tier4/proposal` because TIER IV's proposal was approved by TSC and other members will start to use it.