### PR TITLE
chore: remove quaternion_operation from simulator.repos

### DIFF
--- a/simulator.repos
+++ b/simulator.repos
@@ -3,7 +3,3 @@ repositories:
     type: git
     url: https://github.com/tier4/scenario_simulator_v2.git
     version: master
-  simulator/vendor/quaternion_operation:
-    type: git
-    url: https://github.com/OUXT-Polaris/quaternion_operation.git
-    version: ros2


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

It's released in https://discourse.ros.org/t/new-packages-for-galactic-geochelone-2022-03-14/24688.

## Pre-review checklist for the PR author

PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

Reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has the write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
