### PR TITLE
chore(ansible/docker): use osrf apt repo to install rocker

### DIFF
--- a/ansible/roles/docker/tasks/main.yaml
+++ b/ansible/roles/docker/tasks/main.yaml
@@ -114,9 +114,23 @@
     force: true
     mode: 0775
 
+- name: Authorize OSRF GPG key
+  become: true
+  ansible.builtin.apt_key:
+    url: https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc
+
+# echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/ros-latest.list > /dev/null
+- name: Add OSRF apt repository to source list
+  become: true
+  ansible.builtin.apt_repository:
+    repo: deb http://packages.ros.org/ros/ubuntu {{ lsb_release_cs.stdout }} main
+    filename: ros-latest
+    state: present
+    update_cache: true
+
 - name: Install rocker
   become: true
-  ansible.builtin.pip:
-    name: rocker
-    state: latest
-    executable: pip3
+  ansible.builtin.apt:
+    name:
+      - python3-rocker
+    update_cache: true


### PR DESCRIPTION
Signed-off-by: Esteve Fernandez <esteve.fernandez@tier4.jp>

## Description

<!-- Write a brief description of this PR. -->

Use the recommended way of installing rocker (i.e. via APT)

## Pre-review checklist for the PR author

PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

Reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has the write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
