### PR TITLE
docs: fix English in PR/Issue templates

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,8 @@
-**Note**: Confirm our [contribution guidelines](https://autowarefoundation.github.io/autoware-documentation/main/contributing/) before submitting a pull request.
+**Note**: Confirm the [contribution guidelines](https://autowarefoundation.github.io/autoware-documentation/main/contributing/) before submitting a pull request.
 
 Click the `Preview` tab and select a PR template:
 
 - [Standard change](?expand=1&template=standard-change.md)
 - [Small change](?expand=1&template=small-change.md)
+
+**Do NOT send a PR with this description.**

--- a/.github/PULL_REQUEST_TEMPLATE/small-change.md
+++ b/.github/PULL_REQUEST_TEMPLATE/small-change.md
@@ -4,24 +4,24 @@
 
 ## Pre-review checklist for the PR author
 
-PR author **must** check the checkboxes below when creating the PR.
+The PR author **must** check the checkboxes below when creating the PR.
 
 - [ ] I've confirmed the [contribution guidelines].
 - [ ] The PR follows the [pull request guidelines].
 
 ## In-review checklist for the PR reviewers
 
-Reviewers **must** check the checkboxes below before approval.
+The PR reviewers **must** check the checkboxes below before approval.
 
 - [ ] The PR follows the [pull request guidelines].
 
 ## Post-review checklist for the PR author
 
-PR author **must** check the checkboxes below before merging.
+The PR author **must** check the checkboxes below before merging.
 
 - [ ] There are no open discussions or they are tracked via tickets.
 
-After all checkboxes are checked, anyone who has the write access can merge the PR.
+After all checkboxes are checked, anyone who has write access can merge the PR.
 
 [contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
 [pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/

--- a/.github/PULL_REQUEST_TEMPLATE/standard-change.md
+++ b/.github/PULL_REQUEST_TEMPLATE/standard-change.md
@@ -16,14 +16,14 @@
 
 ## Pre-review checklist for the PR author
 
-PR author **must** check the checkboxes below when creating the PR.
+The PR author **must** check the checkboxes below when creating the PR.
 
 - [ ] I've confirmed the [contribution guidelines].
 - [ ] The PR follows the [pull request guidelines].
 
 ## In-review checklist for the PR reviewers
 
-Reviewers **must** check the checkboxes below before approval.
+The PR reviewers **must** check the checkboxes below before approval.
 
 - [ ] The PR follows the [pull request guidelines].
 - [ ] The PR has been properly tested.
@@ -31,12 +31,12 @@ Reviewers **must** check the checkboxes below before approval.
 
 ## Post-review checklist for the PR author
 
-PR author **must** check the checkboxes below before merging.
+The PR author **must** check the checkboxes below before merging.
 
 - [ ] There are no open discussions or they are tracked via tickets.
 - [ ] The PR is ready for merge.
 
-After all checkboxes are checked, anyone who has the write access can merge the PR.
+After all checkboxes are checked, anyone who has write access can merge the PR.
 
 [contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
 [pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

Fixed some English words to address Grammarly's warnings and to emphasize the notice.

![image](https://user-images.githubusercontent.com/31987104/159910435-ea93d656-ad6b-4f21-aa42-7789260dd5e9.png)


## Pre-review checklist for the PR author

PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

Reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has the write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
