### PR TITLE
feat(autoware.repos): add autoware_msgs repository

### DIFF
--- a/autoware.repos
+++ b/autoware.repos
@@ -1,9 +1,13 @@
 repositories:
   # core
-  core/autoware_msgs:
+  core/autoware_auto_msgs:
     type: git
     url: https://github.com/tier4/autoware_auto_msgs.git # TODO(Tier IV): Move to autowarefoundation/autoware_msgs
     version: tier4/main
+  core/autoware_msgs:
+    type: git
+    url: https://github.com/autowarefoundation/autoware_msgs.git
+    version: main
   core/common:
     type: git
     url: https://github.com/autowarefoundation/autoware_common.git

--- a/autoware.repos
+++ b/autoware.repos
@@ -1,6 +1,6 @@
 repositories:
   # core
-  core/autoware_auto_msgs:
+  core/tmp/autoware_auto_msgs:
     type: git
     url: https://github.com/tier4/autoware_auto_msgs.git # TODO(Tier IV): Move to autowarefoundation/autoware_msgs
     version: tier4/main

--- a/autoware.repos
+++ b/autoware.repos
@@ -21,7 +21,7 @@ repositories:
     type: git
     url: https://github.com/autowarefoundation/autoware.universe.git
     version: main
-  universe/tier4_autoware_msgs:
+  universe/extension_msgs/tier4_autoware_msgs:
     type: git
     url: https://github.com/tier4/tier4_autoware_msgs.git
     version: tier4/universe


### PR DESCRIPTION
Signed-off-by: M. Fatih Cırıt <mfc@leodrive.ai>

## Description

<!-- Write a brief description of this PR. -->
This is a non-breaking change.

Messages roadmap:
| repository      |  old location   |  new location      | description |
|-----------|----------|----------|----------|
| [autoware_auto_msgs](https://github.com/tier4/autoware_auto_msgs.git) | `core/autoware_msgs`  | `core/autoware_auto_msgs` | From Autoware.Auto, used in some places in Universe. |
| [tier4_autoware_msgs](https://github.com/tier4/tier4_autoware_msgs.git) | `universe/tier4_autoware_msgs` | unchanged | From TierIV's architecture proposal, used in some places in Universe. |
| [autoware_msgs](https://github.com/autowarefoundation/autoware_msgs) | nowhere | `core/autoware_msgs` | Will be used in both Universe and Core, the final messages |

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
