### PR TITLE
chore(CPPLINT.cfg): ignore build/include_subdir for relative includes

### DIFF
--- a/CPPLINT.cfg
+++ b/CPPLINT.cfg
@@ -11,3 +11,4 @@ filter=-whitespace/parens         # we allow closing parenthesis to be on the ne
 filter=-whitespace/semicolon      # we allow the developer to decide about whitespace after a semicolon
 filter=-build/header_guard        # we automatically fix the names of header guards using pre-commit
 filter=-build/include_order       # we use the custom include order
+filter=-build/include_subdir      # we allow the style of "foo.hpp"


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

`cpplint 1.6.0` will cause this error.
https://github.com/autowarefoundation/autoware.universe/runs/5820588088?check_suite_focus=true

Since we generally use `ament_cmake_auto` and it puts files under `include/package_name/`, I believe this rule is not important for us.

Related: https://github.com/autowarefoundation/autoware.universe/pull/355

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
