### PR TITLE
chore(.markdownlint.yaml): ignore MD049 to be consistent with Prettier

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -5,3 +5,4 @@ MD024:
 MD033: false
 MD041: false
 MD046: false
+MD049: false

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,3 +1,4 @@
+# See https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md for all rules.
 default: true
 MD013: false
 MD024:


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

`markdownlint v0.31.1` and Prettier will cause a conflict of emphasis sttyles.
https://github.com/DavidAnson/markdownlint/issues/483
https://github.com/autowarefoundation/autoware.universe/runs/5820588088?check_suite_focus=true#step:3:166

If we use Prettier, it will automatically make the style consistent, I'd like to ignore this rule.

Related: https://github.com/autowarefoundation/autoware.universe/pull/355

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
