### PR TITLE
feat(nvidia-library): update tensorrt and cudnn

### DIFF
--- a/ansible/playbooks/universe.yaml
+++ b/ansible/playbooks/universe.yaml
@@ -4,8 +4,8 @@
     - rosdistro: galactic
     - rmw_implementation: rmw_cyclonedds_cpp
     - cuda_version: 11-4
-    - cudnn_version: 8.2.2.26-1+cuda11.4
-    - tensorrt_version: 8.2.2-1+cuda11.4
+    - cudnn_version: 8.2.4.15-1+cuda11.4
+    - tensorrt_version: 8.2.4-1+cuda11.4
   vars_prompt:
     - name: install_nvidia
       prompt: |-

--- a/ansible/roles/tensorrt/README.md
+++ b/ansible/roles/tensorrt/README.md
@@ -17,11 +17,11 @@ For Universe, the `cudnn_version` and `tensorrt_version` variable can also be fo
 ```bash
 # Taken from: https://docs.nvidia.com/deeplearning/tensorrt/install-guide/index.html#installing
 
-cudnn_version="8.2.2.26-1+cuda11.4"
+cudnn_version="8.2.4.15-1+cuda11.4"
 sudo apt-get install libcudnn8=${cudnn_version} libcudnn8-dev=${cudnn_version}
 sudo apt-mark hold libcudnn8 libcudnn8-dev
 
-tensorrt_version="8.2.2-1+cuda11.4"
+tensorrt_version="8.2.4-1+cuda11.4"
 sudo apt-get install libnvinfer8=${tensorrt_version} libnvonnxparsers8=${tensorrt_version} libnvparsers8=${tensorrt_version} libnvinfer-plugin8=${tensorrt_version} libnvinfer-dev=${tensorrt_version} libnvonnxparsers-dev=${tensorrt_version} libnvparsers-dev=${tensorrt_version} libnvinfer-plugin-dev=${tensorrt_version} python3-libnvinfer=${tensorrt_version}
 sudo apt-mark hold libnvinfer8 libnvonnxparsers8 libnvparsers8 libnvinfer-plugin8 libnvinfer-dev libnvonnxparsers-dev libnvparsers-dev libnvinfer-plugin-dev python3-libnvinfer
 ```

--- a/docker/autoware-universe/Dockerfile
+++ b/docker/autoware-universe/Dockerfile
@@ -30,8 +30,8 @@ RUN --mount=type=ssh \
   && rm -rf /var/lib/apt/lists/*
 
 ## Install cuDNN and TensorRT
-ARG CUDNN_VERSION=8.2.2.26-1+cuda11.4
-ARG TENSORRT_VERSION=8.2.2-1+cuda11.4
+ARG CUDNN_VERSION=8.2.4.15-1+cuda11.4
+ARG TENSORRT_VERSION=8.2.4-1+cuda11.4
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install --no-install-recommends \
   libcudnn8=$CUDNN_VERSION \
   libcudnn8-dev=$CUDNN_VERSION \


### PR DESCRIPTION
## Description

update nvidia library version
https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/libcudnn8_8.2.4.15-1+cuda11.4_amd64.deb
https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/libnvinfer8_8.2.4-1+cuda11.4_amd64.deb

All modules which depend on these libraries work correctly. See https://github.com/autowarefoundation/autoware.universe/issues/589.

Nvidia has recently launched a major update to TensorRT library(from 8.2.2 to 8.2.4).
https://docs.nvidia.com/deeplearning/tensorrt/release-notes/tensorrt-8.html#tensorrt-8
This update includes some bug fixes and performance improvements, so it is preferable to update the version if there is no change which breaks the existing features in autoware.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
