### PR TITLE
docs(ansible/tensorrt): remove python3-libnvinfer from the manual installation steps

### DIFF
--- a/ansible/roles/tensorrt/README.md
+++ b/ansible/roles/tensorrt/README.md
@@ -22,6 +22,6 @@ sudo apt-get install libcudnn8=${cudnn_version} libcudnn8-dev=${cudnn_version}
 sudo apt-mark hold libcudnn8 libcudnn8-dev
 
 tensorrt_version="8.2.4-1+cuda11.4"
-sudo apt-get install libnvinfer8=${tensorrt_version} libnvonnxparsers8=${tensorrt_version} libnvparsers8=${tensorrt_version} libnvinfer-plugin8=${tensorrt_version} libnvinfer-dev=${tensorrt_version} libnvonnxparsers-dev=${tensorrt_version} libnvparsers-dev=${tensorrt_version} libnvinfer-plugin-dev=${tensorrt_version} python3-libnvinfer=${tensorrt_version}
-sudo apt-mark hold libnvinfer8 libnvonnxparsers8 libnvparsers8 libnvinfer-plugin8 libnvinfer-dev libnvonnxparsers-dev libnvparsers-dev libnvinfer-plugin-dev python3-libnvinfer
+sudo apt-get install libnvinfer8=${tensorrt_version} libnvonnxparsers8=${tensorrt_version} libnvparsers8=${tensorrt_version} libnvinfer-plugin8=${tensorrt_version} libnvinfer-dev=${tensorrt_version} libnvonnxparsers-dev=${tensorrt_version} libnvparsers-dev=${tensorrt_version} libnvinfer-plugin-dev=${tensorrt_version}
+sudo apt-mark hold libnvinfer8 libnvonnxparsers8 libnvparsers8 libnvinfer-plugin8 libnvinfer-dev libnvonnxparsers-dev libnvparsers-dev libnvinfer-plugin-dev
 ```


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

Removed `python3-libnvinfer` from the manual installation steps following this discussion: 
https://github.com/autowarefoundation/autoware-documentation/pull/76#discussion_r850656739

It's in order to make it consistent with the Ansible scripts.
https://github.com/autowarefoundation/autoware/blob/8b4ed697c56f134224ad14b39b353000afdd4bdd/ansible/roles/tensorrt/tasks/main.yaml#L25-L34

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
