### PR TITLE
ci(docker-build-and-push): fix cron schedule

### DIFF
--- a/.github/workflows/docker-build-and-push-self-hosted.yaml
+++ b/.github/workflows/docker-build-and-push-self-hosted.yaml
@@ -5,7 +5,7 @@ on:
     tags:
       - v*
   schedule:
-    - cron: 0 0 1,15 * 0
+    - cron: 0 0 1,15 * *
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/docker-build-and-push.yaml
+++ b/.github/workflows/docker-build-and-push.yaml
@@ -5,7 +5,7 @@ on:
     tags:
       - v*
   schedule:
-    - cron: 0 0 1,15 * 0
+    - cron: 0 0 1,15 * *
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

It wasn't executed once every two weeks.
https://github.com/autowarefoundation/autoware/actions/workflows/docker-build-and-push.yaml

https://crontab.guru/#0_0_1,15_*_0

![image](https://user-images.githubusercontent.com/31987104/163696962-77c020f2-6661-4139-ae7e-93803fd1b444.png)

https://crontab.guru/#0_0_1,15_*_*

![image](https://user-images.githubusercontent.com/31987104/163696949-2b18bc7f-acc1-40d5-9759-77379314ab1d.png)

Note: Why I set two weeks is to reduce the size of the container registry. If necessary, we can create docker images at any time by using `workflow_dispatch`.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
