### PR TITLE
fix(update-docker-manifest): fix broken workflow

### DIFF
--- a/.github/actions/update-docker-manifest/action.yaml
+++ b/.github/actions/update-docker-manifest/action.yaml
@@ -1,0 +1,107 @@
+name: update-docker-manifest
+description: ""
+
+inputs:
+  package-name:
+    description: ""
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v1
+      with:
+        registry: ghcr.io
+        username: ${{ github.repository_owner }}
+        password: ${{ github.token }}
+
+    - name: Set image name
+      id: set-image-name
+      run: echo "::set-output name=image-name::ghcr.io/${{ github.repository_owner }}/${{ inputs.package-name }}"
+      shell: bash
+
+    - name: Get all tags
+      id: get-all-tags
+      run: |
+        base_url="https://api.github.com/orgs/${{ github.repository_owner }}/packages/container/${{ inputs.package-name }}/versions"
+        echo "base_url: $base_url"
+
+        all_tags=()
+        for page in $(seq 1 10); do
+          page_url="${base_url}?page=$page"
+          echo -e "\npage_url: $page_url"
+
+          page_tags=$(curl -fsSL "$page_url" -H "Authorization: token ${{ github.token }}" | jq ".[].metadata.container.tags[]" | cut -d '"' -f 2)
+          echo -e "\n[page_tags]\n$page_tags"
+
+          if [ "$page_tags" = "" ]; then
+            echo "No tags found in the page $page."
+            break
+          fi
+
+          for tag in $(IFS=$'\n'; echo "$page_tags"); do
+            all_tags+=("$tag")
+          done
+        done
+
+        all_tags=$(printf "%s\n" ${all_tags[@]})
+        echo -e "\n[all_tags]\n$all_tags"
+
+        echo "::set-output name=tags::$(printf "%s " $all_tags)"
+      shell: bash
+
+    - name: Get base tags
+      id: get-base-tags
+      run: |
+        amd64_tags=$(printf "%s\n" $ALL_TAGS | grep "\-amd64" | sed "s/-amd64$//g")
+        arm64_tags=$(printf "%s\n" $ALL_TAGS | grep "\-arm64" | sed "s/-arm64$//g")
+        base_tags=$(printf "%s\n" "$amd64_tags" "$arm64_tags" | sort | uniq)
+
+        echo -e "\n[amd64_tags]\n$amd64_tags"
+        echo -e "\n[arm64_tags]\n$arm64_tags"
+        echo -e "\n[base_tags]\n$base_tags"
+
+        echo "::set-output name=tags::$(printf "%s " $base_tags)"
+      env:
+        ALL_TAGS: ${{ steps.get-all-tags.outputs.tags }}
+      shell: bash
+
+    - name: Create Docker manifest
+      run: |
+        for base_tag in $BASE_TAGS; do
+          echo -e "\nbase_tag: $base_tag"
+
+          amd64_tag=$(printf "%s\n" $ALL_TAGS | grep "$base_tag\-amd64" || true)
+          arm64_tag=$(printf "%s\n" $ALL_TAGS | grep "$base_tag\-arm64" || true)
+
+          echo "amd64_tag: $amd64_tag"
+          echo "arm64_tag: $arm64_tag"
+
+          if [ "$amd64_tag" != "" ]; then
+            amd64_image="${{ steps.set-image-name.outputs.image-name }}:$amd64_tag"
+          else
+            echo "No amd64 tag found for '$base_tag'."
+            amd64_image=""
+          fi
+
+          if [ "$arm64_tag" != "" ]; then
+            arm64_image="${{ steps.set-image-name.outputs.image-name }}:$arm64_tag"
+          else
+            echo "No arm64 tag found for '$base_tag'."
+            arm64_image=""
+          fi
+
+          echo "amd64_image: $amd64_image"
+          echo "arm64_image: $arm64_image"
+
+          docker manifest create ${{ steps.set-image-name.outputs.image-name }}:$base_tag \
+            $amd64_image \
+            $arm64_image
+
+          docker manifest push ${{ steps.set-image-name.outputs.image-name }}:$base_tag
+        done
+      env:
+        ALL_TAGS: ${{ steps.get-all-tags.outputs.tags }}
+        BASE_TAGS: ${{ steps.get-base-tags.outputs.tags }}
+      shell: bash

--- a/.github/workflows/update-docker-manifest.yaml
+++ b/.github/workflows/update-docker-manifest.yaml
@@ -28,28 +28,31 @@ jobs:
           tags=()
           for page in $(seq 1 10); do
             page_url="${base_url}?page=$page"
-            echo "page_url: $page_url"
+            echo -e "\npage_url: $page_url"
 
             page_tags=$(curl -fsSL "$page_url" -H "Authorization: token ${{ github.token }}" | jq ".[].metadata.container.tags[]" | cut -d '"' -f 2)
-            echo "page_tags: "$page_tags""
+            echo -e "\n[page_tags]\n$page_tags"
 
             if [ "$page_tags" = "" ]; then
               echo "No tags found in the page $page."
               break
             fi
 
-            tags+=("$page_tags")
+            for tag in $(IFS=$'\n'; echo "$page_tags"); do
+              tags+=("$tag")
+            done
           done
 
-          echo "tags: "$tags""
+          tags=$(IFS=$'\n'; echo "${tags[*]}")
+          echo -e "\n[tags]\n$tags"
 
           amd64_tags=$(echo "$tags" | grep "\-amd64" | sed "s/-amd64$//g")
           arm64_tags=$(echo "$tags" | grep "\-arm64" | sed "s/-arm64$//g")
           base_tags=$(printf "%s\n" "$amd64_tags" "$arm64_tags" | sort | uniq)
 
-          echo "amd64_tags: "$amd64_tags""
-          echo "arm64_tags: "$arm64_tags""
-          echo "base_tags: "$base_tags""
+          echo -e "\n[amd64_tags]\n$amd64_tags"
+          echo -e "\n[arm64_tags]\n$arm64_tags"
+          echo -e "\n[base_tags]\n$base_tags"
 
           for base_tag in $base_tags; do
             echo -e "\nbase_tag: $base_tag"

--- a/.github/workflows/update-docker-manifest.yaml
+++ b/.github/workflows/update-docker-manifest.yaml
@@ -22,15 +22,32 @@ jobs:
         run: |
           package_full_name=ghcr.io/${{ github.repository_owner }}/${{ env.PACKAGE_NAME }}
 
-          url="https://api.github.com/orgs/${{ github.repository_owner }}/packages/container/${{ env.PACKAGE_NAME }}/versions"
+          base_url="https://api.github.com/orgs/${{ github.repository_owner }}/packages/container/${{ env.PACKAGE_NAME }}/versions"
+          echo "base_url: $base_url"
 
-          echo "url: $url"
-          tags=$(curl -fsSL "$url" -H "Authorization: token ${{ github.token }}" | jq ".[].metadata.container.tags[]" | cut -d '"' -f 2)
+          tags=()
+          for page in $(seq 1 10); do
+            page_url="${base_url}?page=$page"
+            echo "page_url: $page_url"
+
+            page_tags=$(curl -fsSL "$page_url" -H "Authorization: token ${{ github.token }}" | jq ".[].metadata.container.tags[]" | cut -d '"' -f 2)
+            echo "page_tags: "$page_tags""
+
+            if [ "$page_tags" = "" ]; then
+              echo "No tags found in the page $page."
+              break
+            fi
+
+            tags+=("$page_tags")
+          done
+
+          echo "tags: "$tags""
 
           amd64_tags=$(echo "$tags" | grep "\-amd64" | sed "s/-amd64$//g")
           arm64_tags=$(echo "$tags" | grep "\-arm64" | sed "s/-arm64$//g")
           base_tags=$(printf "%s\n" "$amd64_tags" "$arm64_tags" | sort | uniq)
 
+          echo "tags: "$tags""
           echo "amd64_tags: "$amd64_tags""
           echo "arm64_tags: "$arm64_tags""
           echo "base_tags: "$base_tags""

--- a/.github/workflows/update-docker-manifest.yaml
+++ b/.github/workflows/update-docker-manifest.yaml
@@ -8,81 +8,11 @@ on:
 jobs:
   update-docker-manifest:
     runs-on: ubuntu-latest
-    env:
-      PACKAGE_NAME: autoware-universe
     steps:
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v1
+      - name: Check out repository
+        uses: actions/checkout@v3
+
+      - name: Update Docker manifest for 'autoware-universe'
+        uses: ./.github/actions/update-docker-manifest
         with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ github.token }}
-
-      - name: Create Docker manifest
-        run: |
-          package_full_name=ghcr.io/${{ github.repository_owner }}/${{ env.PACKAGE_NAME }}
-
-          base_url="https://api.github.com/orgs/${{ github.repository_owner }}/packages/container/${{ env.PACKAGE_NAME }}/versions"
-          echo "base_url: $base_url"
-
-          tags=()
-          for page in $(seq 1 10); do
-            page_url="${base_url}?page=$page"
-            echo -e "\npage_url: $page_url"
-
-            page_tags=$(curl -fsSL "$page_url" -H "Authorization: token ${{ github.token }}" | jq ".[].metadata.container.tags[]" | cut -d '"' -f 2)
-            echo -e "\n[page_tags]\n$page_tags"
-
-            if [ "$page_tags" = "" ]; then
-              echo "No tags found in the page $page."
-              break
-            fi
-
-            for tag in $(IFS=$'\n'; echo "$page_tags"); do
-              tags+=("$tag")
-            done
-          done
-
-          tags=$(IFS=$'\n'; echo "${tags[*]}")
-          echo -e "\n[tags]\n$tags"
-
-          amd64_tags=$(echo "$tags" | grep "\-amd64" | sed "s/-amd64$//g")
-          arm64_tags=$(echo "$tags" | grep "\-arm64" | sed "s/-arm64$//g")
-          base_tags=$(printf "%s\n" "$amd64_tags" "$arm64_tags" | sort | uniq)
-
-          echo -e "\n[amd64_tags]\n$amd64_tags"
-          echo -e "\n[arm64_tags]\n$arm64_tags"
-          echo -e "\n[base_tags]\n$base_tags"
-
-          for base_tag in $base_tags; do
-            echo -e "\nbase_tag: $base_tag"
-
-            amd64_tag=$(echo "$tags" | grep "$base_tag\-amd64" || true)
-            arm64_tag=$(echo "$tags" | grep "$base_tag\-arm64" || true)
-
-            echo "amd64_tag: $amd64_tag"
-            echo "arm64_tag: $arm64_tag"
-
-            if [ "$amd64_tag" != "" ]; then
-              amd64_image_name="$package_full_name:$amd64_tag"
-            else
-              echo "No amd64 tag found for '$base_tag'."
-              amd64_image_name=""
-            fi
-
-            if [ "$arm64_tag" != "" ]; then
-              arm64_image_name="$package_full_name:$arm64_tag"
-            else
-              echo "No arm64 tag found for '$base_tag'."
-              arm64_image_name=""
-            fi
-
-            echo "amd64_image_name: $amd64_image_name"
-            echo "arm64_image_name: $arm64_image_name"
-
-            docker manifest create $package_full_name:$base_tag \
-              $amd64_image_name \
-              $arm64_image_name
-
-            docker manifest push $package_full_name:$base_tag
-          done
+          package-name: autoware-universe

--- a/.github/workflows/update-docker-manifest.yaml
+++ b/.github/workflows/update-docker-manifest.yaml
@@ -2,7 +2,7 @@ name: update-docker-manifest
 
 on:
   schedule:
-    - cron: 0 0 * * 0
+    - cron: 0 0 * * *
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/update-docker-manifest.yaml
+++ b/.github/workflows/update-docker-manifest.yaml
@@ -47,22 +47,39 @@ jobs:
           arm64_tags=$(echo "$tags" | grep "\-arm64" | sed "s/-arm64$//g")
           base_tags=$(printf "%s\n" "$amd64_tags" "$arm64_tags" | sort | uniq)
 
-          echo "tags: "$tags""
           echo "amd64_tags: "$amd64_tags""
           echo "arm64_tags: "$arm64_tags""
           echo "base_tags: "$base_tags""
 
           for base_tag in $base_tags; do
-            amd64_tag="$package_full_name":$(echo "$tags" | grep "$base_tag\-amd64")
-            arm64_tag="$package_full_name":$(echo "$tags" | grep "$base_tag\-arm64")
+            echo -e "\nbase_tag: $base_tag"
 
-            echo "base_tag: $base_tag"
+            amd64_tag=$(echo "$tags" | grep "$base_tag\-amd64" || true)
+            arm64_tag=$(echo "$tags" | grep "$base_tag\-arm64" || true)
+
             echo "amd64_tag: $amd64_tag"
             echo "arm64_tag: $arm64_tag"
 
+            if [ "$amd64_tag" != "" ]; then
+              amd64_image_name="$package_full_name:$amd64_tag"
+            else
+              echo "No amd64 tag found for '$base_tag'."
+              amd64_image_name=""
+            fi
+
+            if [ "$arm64_tag" != "" ]; then
+              arm64_image_name="$package_full_name:$arm64_tag"
+            else
+              echo "No arm64 tag found for '$base_tag'."
+              arm64_image_name=""
+            fi
+
+            echo "amd64_image_name: $amd64_image_name"
+            echo "arm64_image_name: $arm64_image_name"
+
             docker manifest create $package_full_name:$base_tag \
-              $amd64_tag \
-              $arm64_tag
+              $amd64_image_name \
+              $arm64_image_name
 
             docker manifest push $package_full_name:$base_tag
           done


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

Fixed the `update-docker-manifest` workflow.
https://github.com/autowarefoundation/autoware/runs/6051121373?check_suite_focus=true

- The page number is necessary.
  - https://docs.github.com/en/rest/reference/packages#get-all-package-versions-for-a-package-owned-by-an-organization
- Sometimes a certain architecture's version is missing. (Due to the build failure.)
  - For example, `20220417` in https://github.com/autowarefoundation/autoware/pkgs/container/autoware-universe/versions

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
