### PR TITLE
ci: add github-release.yaml

### DIFF
--- a/.github/workflows/github-release.yaml
+++ b/.github/workflows/github-release.yaml
@@ -2,11 +2,13 @@ name: github-release
 
 on:
   push:
+    branches:
+      - beta/v*
     tags:
       - v*
   workflow_dispatch:
     inputs:
-      tag-name:
+      beta-branch-or-tag-name:
         type: string
         required: true
 
@@ -18,22 +20,35 @@ jobs:
         id: set-tag-name
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            TAG_NAME="${{ github.event.inputs.tag-name }}"
+            REF_NAME="${{ github.event.inputs.beta-branch-or-tag-name }}"
           else
-            TAG_NAME="${{ github.ref_name }}"
+            REF_NAME="${{ github.ref_name }}"
           fi
 
-          echo ::set-output name=tag-name::"$TAG_NAME"
+          echo ::set-output name=ref-name::"$REF_NAME"
+          echo ::set-output name=tag-name::"${REF_NAME#beta/}"
 
       - name: Check out repository
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          ref: ${{ steps.set-tag-name.outputs.tag-name }}
+          ref: ${{ steps.set-tag-name.outputs.ref-name }}
+
+      - name: Create a temporary local tag for beta branches
+        run: |
+          if [[ "${{ steps.set-tag-name.outputs.ref-name }}" =~ "beta/" ]]; then
+            git tag "${{ steps.set-tag-name.outputs.tag-name }}"
+          fi
 
       - name: Run generate-changelog
         id: generate-changelog
         uses: autowarefoundation/autoware-github-actions/generate-changelog@v1
+
+      - name: Remove the temporary local tag for beta branches
+        run: |
+          if [[ "${{ steps.set-tag-name.outputs.ref-name }}" =~ "beta/" ]]; then
+            git tag -d "${{ steps.set-tag-name.outputs.tag-name }}"
+          fi
 
       - name: Release to GitHub
         run: |

--- a/.github/workflows/github-release.yaml
+++ b/.github/workflows/github-release.yaml
@@ -5,15 +5,31 @@ on:
     tags:
       - v*
   workflow_dispatch:
+    inputs:
+      tag-name:
+        type: string
+        required: true
 
 jobs:
   github-release:
     runs-on: ubuntu-latest
     steps:
+      - name: Set tag name
+        id: set-tag-name
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            TAG_NAME="${{ github.event.inputs.tag-name }}"
+          else
+            TAG_NAME="${{ github.ref_name }}"
+          fi
+
+          echo ::set-output name=tag-name::"$TAG_NAME"
+
       - name: Check out repository
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          ref: ${{ steps.set-tag-name.outputs.tag-name }}
 
       - name: Run generate-changelog
         id: generate-changelog
@@ -21,9 +37,9 @@ jobs:
 
       - name: Release to GitHub
         run: |
-          gh release create "${{ github.ref_name }}" \
+          gh release create "${{ steps.set-tag-name.outputs.tag-name }}" \
             --draft \
-            --title "Release ${{ github.ref_name }}" \
+            --title "Release ${{ steps.set-tag-name.outputs.tag-name }}" \
             --notes "$NOTES"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/github-release.yaml
+++ b/.github/workflows/github-release.yaml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - v*
+  workflow_dispatch:
 
 jobs:
   github-release:

--- a/.github/workflows/github-release.yaml
+++ b/.github/workflows/github-release.yaml
@@ -1,0 +1,29 @@
+name: github-release
+
+on:
+  push:
+    tags:
+      - v*
+
+jobs:
+  github-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Run generate-changelog
+        id: generate-changelog
+        uses: autowarefoundation/autoware-github-actions/generate-changelog@v1
+
+      - name: Release to GitHub
+        run: |
+          gh release create "${{ github.ref_name }}" \
+            --draft \
+            --title "Release ${{ github.ref_name }}" \
+            --notes "$NOTES"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NOTES: ${{ steps.generate-changelog.outputs.changelog }}


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

It's useful if we can prepare releases after pushing a tag.
I'd like to add this workflow to all Autoware repositories.

It's already used and tested in `autoware-github-actions`.
https://github.com/autowarefoundation/autoware-github-actions/releases

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
