### PR TITLE
ci(github-release): set target name

### DIFF
--- a/.github/workflows/github-release.yaml
+++ b/.github/workflows/github-release.yaml
@@ -34,9 +34,16 @@ jobs:
           fetch-depth: 0
           ref: ${{ steps.set-tag-name.outputs.ref-name }}
 
-      - name: Create a temporary local tag for beta branches
+      - name: Set target name for beta branches
+        id: set-target-name
         run: |
           if [[ "${{ steps.set-tag-name.outputs.ref-name }}" =~ "beta/" ]]; then
+            echo ::set-output name=target-name::"${{ steps.set-tag-name.outputs.ref-name }}"
+          fi
+
+      - name: Create a local tag for beta branches
+        run: |
+          if [ "${{ steps.set-target-name.outputs.target-name }}" != "" ]; then
             git tag "${{ steps.set-tag-name.outputs.tag-name }}"
           fi
 
@@ -44,16 +51,11 @@ jobs:
         id: generate-changelog
         uses: autowarefoundation/autoware-github-actions/generate-changelog@v1
 
-      - name: Remove the temporary local tag for beta branches
-        run: |
-          if [[ "${{ steps.set-tag-name.outputs.ref-name }}" =~ "beta/" ]]; then
-            git tag -d "${{ steps.set-tag-name.outputs.tag-name }}"
-          fi
-
       - name: Release to GitHub
         run: |
           gh release create "${{ steps.set-tag-name.outputs.tag-name }}" \
             --draft \
+            --target "${{ steps.set-target-name.outputs.target-name }}" \
             --title "Release ${{ steps.set-tag-name.outputs.tag-name }}" \
             --notes "$NOTES"
         env:


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

When we create a release from a branch, I had to set `--target` to the target branch name.
https://cli.github.com/manual/gh_release_create

It should be empty when we create a release from a tag, otherwise, it raises a validation error. Therefore, I created the `set-target-name` job.

I've tested it in my fork. Previously, the `Target` was `main`.
https://github.com/kenji-miyake/autoware-github-actions/releases
![image](https://user-images.githubusercontent.com/31987104/164490400-8fdf686a-2229-42ab-af29-1ddda1ecfdba.png)

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
