### PR TITLE
ci(sync-files): check if APP_ID is set

### DIFF
--- a/.github/workflows/sync-files.yaml
+++ b/.github/workflows/sync-files.yaml
@@ -6,7 +6,14 @@ on:
   workflow_dispatch:
 
 jobs:
+  check-secret:
+    uses: autowarefoundation/autoware-github-actions/.github/workflows/check-secret.yaml@v1
+    secrets:
+      secret: ${{ secrets.APP_ID }}
+
   sync-files:
+    needs: check-secret
+    if: ${{ needs.check-secret.outputs.set == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - name: Generate token


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

Applied https://github.com/autowarefoundation/autoware-github-actions/pull/138.

As explained in https://github.com/autowarefoundation/autoware.universe/issues/319, sync-files will fail in forks if APP_ID is not set.

- https://github.com/kenji-miyake/autoware.universe/actions/workflows/sync-files.yaml
![image](https://user-images.githubusercontent.com/31987104/165073348-12f38337-2163-4417-9230-c34d07a3a3d7.png)

- https://github.com/kenji-miyake/autoware.universe/actions/runs/2025544541
![image](https://user-images.githubusercontent.com/31987104/165073385-9a80d3b4-cd7f-4d61-bd85-2e55560cf097.png)

---

To resolve this, I changed to check if `APP_ID` is set before running the normal job.

For `pre-commit`, since it's not a scheduled workflow, I didn't apply this.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
