### PR TITLE
chore(clang-format): update to 14.0.1

### DIFF
--- a/ansible/roles/pre_commit/README.md
+++ b/ansible/roles/pre_commit/README.md
@@ -14,7 +14,7 @@ The `clang_format_version` variable can also be found in:
 [./defaults/main.yaml](./defaults/main.yaml)
 
 ```bash
-clang_format_version=13.0.0
+clang_format_version=14.0.1
 pip3 install pre-commit clang-format==${clang_format_version}
 
 # Install Golang (Add Go PPA for shfmt)

--- a/ansible/roles/pre_commit/defaults/main.yaml
+++ b/ansible/roles/pre_commit/defaults/main.yaml
@@ -1,1 +1,1 @@
-clang_format_version: 13.0.0
+clang_format_version: 14.0.1


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

`Ubuntu 22.04 LTS (Jammy Jellyfish)` uses `clang-format-14` by default.
https://packages.ubuntu.com/jammy/clang-format

And now `14.0.1` is the latest of `pip`.
https://pypi.org/project/clang-format/

![image](https://user-images.githubusercontent.com/31987104/165202569-c1fd449a-f7d1-4f8c-8db6-a4a9420464d1.png)

I'll update `.pre-commit-config.yaml` in each repository after this is merged.
https://github.com/autowarefoundation/autoware.universe/pull/726

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
