### PR TITLE
fix(ansible/rocker): use ROS 2 apt repository for Ubuntu 22.04

### DIFF
--- a/ansible/roles/rocker/tasks/main.yaml
+++ b/ansible/roles/rocker/tasks/main.yaml
@@ -10,16 +10,16 @@
   register: deb_architecture
   changed_when: false
 
-- name: Save result of 'source /etc/os-release && echo $UBUNTU_CODENAME'
-  ansible.builtin.shell: bash -c 'source /etc/os-release && echo $UBUNTU_CODENAME'
-  register: ubuntu_codename
+- name: Save result of 'lsb_release -cs'
+  ansible.builtin.command: lsb_release -cs
+  register: lsb_release_cs
   changed_when: false
 
-# echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(source /etc/os-release && echo $UBUNTU_CODENAME) main" | sudo tee /etc/apt/sources.list.d/ros2.list > /dev/null
+# echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/ros2.list > /dev/null
 - name: Add ROS 2 apt repository to source list
   become: true
   ansible.builtin.apt_repository:
-    repo: deb [arch={{ deb_architecture.stdout }} signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu {{ ubuntu_codename.stdout }} main
+    repo: deb [arch={{ deb_architecture.stdout }} signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu {{ lsb_release_cs.stdout }} main
     filename: ros2
     state: present
     update_cache: true

--- a/ansible/roles/rocker/tasks/main.yaml
+++ b/ansible/roles/rocker/tasks/main.yaml
@@ -1,14 +1,26 @@
-- name: Authorize OSRF GPG key
+# sudo curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg
+- name: Authorize ROS GPG key
   become: true
-  ansible.builtin.apt_key:
-    url: https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc
+  ansible.builtin.get_url:
+    url: https://raw.githubusercontent.com/ros/rosdistro/master/ros.key
+    dest: /usr/share/keyrings/ros-archive-keyring.gpg
 
-# echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/ros-latest.list > /dev/null
-- name: Add OSRF apt repository to source list
+- name: Save result of 'dpkg --print-architecture'
+  ansible.builtin.command: dpkg --print-architecture
+  register: deb_architecture
+  changed_when: false
+
+- name: Save result of 'source /etc/os-release && echo $UBUNTU_CODENAME'
+  ansible.builtin.shell: bash -c 'source /etc/os-release && echo $UBUNTU_CODENAME'
+  register: ubuntu_codename
+  changed_when: false
+
+# echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(source /etc/os-release && echo $UBUNTU_CODENAME) main" | sudo tee /etc/apt/sources.list.d/ros2.list > /dev/null
+- name: Add ROS 2 apt repository to source list
   become: true
   ansible.builtin.apt_repository:
-    repo: deb http://packages.ros.org/ros/ubuntu {{ lsb_release_cs.stdout }} main
-    filename: ros-latest
+    repo: deb [arch={{ deb_architecture.stdout }} signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu {{ ubuntu_codename.stdout }} main
+    filename: ros2
     state: present
     update_cache: true
 


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

There isn't `jammy` in the `ros` repository, but is in the `ros2` repository.

http://packages.ros.org/ros/ubuntu/dists/
http://packages.ros.org/ros2/ubuntu/dists/

This causes an error https://github.com/autowarefoundation/autoware/discussions/239#discussioncomment-2645081.

I confirmed `python3-rocker` is listed here.
http://packages.ros.org/ros2/ubuntu/dists/jammy/main/binary-amd64/Packages

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
