### PR TITLE
feat: add plotjuggler into docker image

### DIFF
--- a/ansible/playbooks/core.yaml
+++ b/ansible/playbooks/core.yaml
@@ -8,6 +8,7 @@
           - rmw_implementation: "{{ rmw_implementation }}"
   roles:
     - role: autoware.dev_env.autoware_core
+    - role: autoware.dev_env.plotjuggler
     - role: autoware.dev_env.pre_commit
     - role: autoware.dev_env.ros2
     - role: autoware.dev_env.ros2_dev_tools

--- a/ansible/playbooks/universe.yaml
+++ b/ansible/playbooks/universe.yaml
@@ -37,3 +37,5 @@
     - role: autoware.dev_env.pacmod
     - role: autoware.dev_env.tensorrt
       when: install_nvidia == 'y'
+    - role: autoware.dev_env.plotjuggler
+

--- a/ansible/playbooks/universe.yaml
+++ b/ansible/playbooks/universe.yaml
@@ -35,6 +35,6 @@
     - role: autoware.dev_env.cuda
       when: install_nvidia == 'y'
     - role: autoware.dev_env.pacmod
+    - role: autoware.dev_env.plotjuggler
     - role: autoware.dev_env.tensorrt
       when: install_nvidia == 'y'
-    - role: autoware.dev_env.plotjuggler

--- a/ansible/playbooks/universe.yaml
+++ b/ansible/playbooks/universe.yaml
@@ -25,6 +25,7 @@
   roles:
     # Core
     - role: autoware.dev_env.autoware_core
+    - role: autoware.dev_env.plotjuggler
     - role: autoware.dev_env.pre_commit
     - role: autoware.dev_env.ros2
     - role: autoware.dev_env.ros2_dev_tools
@@ -35,6 +36,5 @@
     - role: autoware.dev_env.cuda
       when: install_nvidia == 'y'
     - role: autoware.dev_env.pacmod
-    - role: autoware.dev_env.plotjuggler
     - role: autoware.dev_env.tensorrt
       when: install_nvidia == 'y'

--- a/ansible/playbooks/universe.yaml
+++ b/ansible/playbooks/universe.yaml
@@ -38,4 +38,3 @@
     - role: autoware.dev_env.tensorrt
       when: install_nvidia == 'y'
     - role: autoware.dev_env.plotjuggler
-

--- a/ansible/roles/plotjuggler/README.md
+++ b/ansible/roles/plotjuggler/README.md
@@ -1,0 +1,44 @@
+# ros2_dev_tools
+
+This role installs ROS 2 development tools following [this page](https://docs.ros.org/en/galactic/Installation/Ubuntu-Development-Setup.html).
+
+## Inputs
+
+None.
+
+## Manual Installation
+
+```bash
+# Taken from https://docs.ros.org/en/galactic/Installation/Ubuntu-Development-Setup.html
+sudo apt update && sudo apt install -y \
+  build-essential \
+  cmake \
+  git \
+  python3-colcon-common-extensions \
+  python3-flake8 \
+  python3-pip \
+  python3-pytest-cov \
+  python3-rosdep \
+  python3-setuptools \
+  python3-vcstool \
+  wget
+
+# Install some pip packages needed for testing
+python3 -m pip install -U \
+  flake8-blind-except \
+  flake8-builtins \
+  flake8-class-newline \
+  flake8-comprehensions \
+  flake8-deprecated \
+  flake8-docstrings \
+  flake8-import-order \
+  flake8-quotes \
+  pytest-repeat \
+  pytest-rerunfailures \
+  pytest \
+  setuptools
+
+# Initialize rosdep
+sudo rosdep init
+rosdep update
+```

--- a/ansible/roles/plotjuggler/README.md
+++ b/ansible/roles/plotjuggler/README.md
@@ -1,6 +1,6 @@
-# ros2_dev_tools
+# plotjuggler
 
-This role installs ROS 2 development tools following [this page](https://docs.ros.org/en/galactic/Installation/Ubuntu-Development-Setup.html).
+This role installs PlotJuggler. You can access detailed information about PlotJuggler with this [link](https://www.plotjuggler.io/).
 
 ## Inputs
 
@@ -9,36 +9,6 @@ None.
 ## Manual Installation
 
 ```bash
-# Taken from https://docs.ros.org/en/galactic/Installation/Ubuntu-Development-Setup.html
 sudo apt update && sudo apt install -y \
-  build-essential \
-  cmake \
-  git \
-  python3-colcon-common-extensions \
-  python3-flake8 \
-  python3-pip \
-  python3-pytest-cov \
-  python3-rosdep \
-  python3-setuptools \
-  python3-vcstool \
-  wget
-
-# Install some pip packages needed for testing
-python3 -m pip install -U \
-  flake8-blind-except \
-  flake8-builtins \
-  flake8-class-newline \
-  flake8-comprehensions \
-  flake8-deprecated \
-  flake8-docstrings \
-  flake8-import-order \
-  flake8-quotes \
-  pytest-repeat \
-  pytest-rerunfailures \
-  pytest \
-  setuptools
-
-# Initialize rosdep
-sudo rosdep init
-rosdep update
+  ros-galactic-plotjuggler-ros
 ```

--- a/ansible/roles/plotjuggler/meta/main.yaml
+++ b/ansible/roles/plotjuggler/meta/main.yaml
@@ -1,0 +1,2 @@
+dependencies:
+  - ros2

--- a/ansible/roles/plotjuggler/tasks/main.yaml
+++ b/ansible/roles/plotjuggler/tasks/main.yaml
@@ -5,9 +5,3 @@
       - ros-galactic-plotjuggler-ros
     state: latest
     update_cache: true
-
-- name: Run 'sudo rosdep init'
-  become: true
-  ansible.builtin.command:
-    cmd: rosdep init
-    creates: /etc/ros/rosdep/sources.list.d/20-default.list

--- a/ansible/roles/plotjuggler/tasks/main.yaml
+++ b/ansible/roles/plotjuggler/tasks/main.yaml
@@ -1,0 +1,14 @@
+- name: Install apt packages
+  become: true
+  ansible.builtin.apt:
+    name:
+      - ros-galactic-plotjuggler-ros
+    state: latest
+    update_cache: true
+
+
+- name: Run 'sudo rosdep init'
+  become: true
+  ansible.builtin.command:
+    cmd: rosdep init
+    creates: /etc/ros/rosdep/sources.list.d/20-default.list

--- a/ansible/roles/plotjuggler/tasks/main.yaml
+++ b/ansible/roles/plotjuggler/tasks/main.yaml
@@ -6,7 +6,6 @@
     state: latest
     update_cache: true
 
-
 - name: Run 'sudo rosdep init'
   become: true
   ansible.builtin.command:


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

Discussion: #235

Plotjuggler is useful tool to visualize ros messages. It is fully compatible with ROS2. Also it can export the visualized topic data and statistics (like max, min, average values) as CVS file. It can be used for testing the nodes especially in localization and control modules. 
As far as I know, It is used for debugging in `trajectory_follower_nodes` and also I am planning to use it in `control_performance_analysis` module to evaluate the controller's performance. I want to suggest that it should be added into docker image.

You can access detailed information about PlotJuggler with this [link](https://www.plotjuggler.io/).

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
