### PR TITLE
ci(docker-build-and-push): remove a workaround for docker/bake-action

### DIFF
--- a/.github/actions/docker-build-and-push/action.yaml
+++ b/.github/actions/docker-build-and-push/action.yaml
@@ -85,21 +85,13 @@ runs:
         username: ${{ github.repository_owner }}
         password: ${{ github.token }}
 
-    # For https://github.com/docker/buildx/issues/756
-    - name: Merge json files
-      run: |
-        jq -s ".[0] * .[1]" \
-          "${{ steps.meta-devel.outputs.bake-file }}" \
-          "${{ steps.meta-prebuilt.outputs.bake-file }}" \
-          > bake.json
-      shell: bash
-
     - name: Build and push
       uses: docker/bake-action@v2
       with:
         push: ${{ github.ref_name == github.event.repository.default_branch }}
         files: |
           docker/${{ inputs.bake-target }}/docker-bake.hcl
-          bake.json
+          ${{ steps.meta-devel.outputs.bake-file }}
+          ${{ steps.meta-prebuilt.outputs.bake-file }}
         set: |
           ${{ inputs.build-args }}

--- a/.github/actions/docker-build-and-push/action.yaml
+++ b/.github/actions/docker-build-and-push/action.yaml
@@ -85,6 +85,11 @@ runs:
         username: ${{ github.repository_owner }}
         password: ${{ github.token }}
 
+    - name: tmp
+      run: |
+        echo "github.ref_name: ${{ github.ref_name }}"
+      shell: bash
+
     - name: Build and push
       uses: docker/bake-action@v2
       with:

--- a/.github/workflows/docker-build-and-push-humble-self-hosted.yaml
+++ b/.github/workflows/docker-build-and-push-humble-self-hosted.yaml
@@ -23,7 +23,7 @@ jobs:
             setup-args: --no-nvidia
             additional-tag-suffix: ""
           - name: cuda
-            base_image_env: base_image
+            base_image_env: cuda_base_image
             setup-args: --no-cuda-drivers
             additional-tag-suffix: -cuda
     steps:

--- a/.github/workflows/docker-build-and-push-humble-self-hosted.yaml
+++ b/.github/workflows/docker-build-and-push-humble-self-hosted.yaml
@@ -18,8 +18,14 @@ jobs:
           - no-cuda
           - cuda
         include:
-          - { name: no-cuda, setup-args: --no-nvidia, additional-tag-suffix: "" }
-          - { name: cuda, setup-args: --no-cuda-drivers, additional-tag-suffix: -cuda }
+          - name: no-cuda
+            base_image_env: base_image
+            setup-args: --no-nvidia
+            additional-tag-suffix: ""
+          - name: cuda
+            base_image_env: base_image
+            setup-args: --no-cuda-drivers
+            additional-tag-suffix: -cuda
     steps:
       # https://github.com/actions/checkout/issues/211
       - name: Change permission of workspace
@@ -48,7 +54,7 @@ jobs:
           build-args: |
             *.platform=linux/arm64
             *.args.ROS_DISTRO=${{ env.rosdistro }}
-            *.args.BASE_IMAGE=${{ env.base_image }}
+            *.args.BASE_IMAGE=${{ env[format('{0}', matrix.base_image_env)] }}
             *.args.SETUP_ARGS=${{ matrix.setup-args }}
           tag-prefix: ${{ env.rosdistro }}-
           tag-suffix: ${{ matrix.additional-tag-suffix }}-arm64

--- a/.github/workflows/docker-build-and-push-humble.yaml
+++ b/.github/workflows/docker-build-and-push-humble.yaml
@@ -18,8 +18,14 @@ jobs:
           - no-cuda
           - cuda
         include:
-          - { name: no-cuda, setup-args: --no-nvidia, additional-tag-suffix: "" }
-          - { name: cuda, setup-args: --no-cuda-drivers, additional-tag-suffix: -cuda }
+          - name: no-cuda
+            base_image_env: base_image
+            setup-args: --no-nvidia
+            additional-tag-suffix: ""
+          - name: cuda
+            base_image_env: base_image
+            setup-args: --no-cuda-drivers
+            additional-tag-suffix: -cuda
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -43,7 +49,7 @@ jobs:
           build-args: |
             *.platform=linux/amd64
             *.args.ROS_DISTRO=${{ env.rosdistro }}
-            *.args.BASE_IMAGE=${{ env.base_image }}
+            *.args.BASE_IMAGE=${{ env[format('{0}', matrix.base_image_env)] }}
             *.args.SETUP_ARGS=${{ matrix.setup-args }}
           tag-prefix: ${{ env.rosdistro }}-
           tag-suffix: ${{ matrix.additional-tag-suffix }}-amd64

--- a/.github/workflows/docker-build-and-push-humble.yaml
+++ b/.github/workflows/docker-build-and-push-humble.yaml
@@ -23,7 +23,7 @@ jobs:
             setup-args: --no-nvidia
             additional-tag-suffix: ""
           - name: cuda
-            base_image_env: base_image
+            base_image_env: cuda_base_image
             setup-args: --no-cuda-drivers
             additional-tag-suffix: -cuda
     steps:

--- a/.github/workflows/docker-build-and-push-main-self-hosted.yaml
+++ b/.github/workflows/docker-build-and-push-main-self-hosted.yaml
@@ -23,7 +23,7 @@ jobs:
             setup-args: --no-nvidia
             additional-tag-suffix: ""
           - name: cuda
-            base_image_env: base_image
+            base_image_env: cuda_base_image
             setup-args: --no-cuda-drivers
             additional-tag-suffix: -cuda
     steps:

--- a/.github/workflows/docker-build-and-push-main-self-hosted.yaml
+++ b/.github/workflows/docker-build-and-push-main-self-hosted.yaml
@@ -18,8 +18,14 @@ jobs:
           - no-cuda
           - cuda
         include:
-          - { name: no-cuda, setup-args: --no-nvidia, additional-tag-suffix: "" }
-          - { name: cuda, setup-args: --no-cuda-drivers, additional-tag-suffix: -cuda }
+          - name: no-cuda
+            base_image_env: base_image
+            setup-args: --no-nvidia
+            additional-tag-suffix: ""
+          - name: cuda
+            base_image_env: base_image
+            setup-args: --no-cuda-drivers
+            additional-tag-suffix: -cuda
     steps:
       # https://github.com/actions/checkout/issues/211
       - name: Change permission of workspace
@@ -48,7 +54,7 @@ jobs:
           build-args: |
             *.platform=linux/arm64
             *.args.ROS_DISTRO=${{ env.rosdistro }}
-            *.args.BASE_IMAGE=${{ env.base_image }}
+            *.args.BASE_IMAGE=${{ env[format('{0}', matrix.base_image_env)] }}
             *.args.SETUP_ARGS=${{ matrix.setup-args }}
           tag-prefix: ${{ env.rosdistro }}-
           tag-suffix: ${{ matrix.additional-tag-suffix }}-arm64

--- a/.github/workflows/docker-build-and-push-main.yaml
+++ b/.github/workflows/docker-build-and-push-main.yaml
@@ -18,8 +18,14 @@ jobs:
           - no-cuda
           - cuda
         include:
-          - { name: no-cuda, setup-args: --no-nvidia, additional-tag-suffix: "" }
-          - { name: cuda, setup-args: --no-cuda-drivers, additional-tag-suffix: -cuda }
+          - name: no-cuda
+            base_image_env: base_image
+            setup-args: --no-nvidia
+            additional-tag-suffix: ""
+          - name: cuda
+            base_image_env: base_image
+            setup-args: --no-cuda-drivers
+            additional-tag-suffix: -cuda
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -43,7 +49,7 @@ jobs:
           build-args: |
             *.platform=linux/amd64
             *.args.ROS_DISTRO=${{ env.rosdistro }}
-            *.args.BASE_IMAGE=${{ env.base_image }}
+            *.args.BASE_IMAGE=${{ env[format('{0}', matrix.base_image_env)] }}
             *.args.SETUP_ARGS=${{ matrix.setup-args }}
           tag-prefix: ${{ env.rosdistro }}-
           tag-suffix: ${{ matrix.additional-tag-suffix }}-amd64

--- a/.github/workflows/docker-build-and-push-main.yaml
+++ b/.github/workflows/docker-build-and-push-main.yaml
@@ -23,7 +23,7 @@ jobs:
             setup-args: --no-nvidia
             additional-tag-suffix: ""
           - name: cuda
-            base_image_env: base_image
+            base_image_env: cuda_base_image
             setup-args: --no-cuda-drivers
             additional-tag-suffix: -cuda
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
         args: [-c, .markdownlint.yaml, --fix]
 
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v2.6.2
+    rev: v2.7.1
     hooks:
       - id: prettier
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ To learn more about using or developing Autoware, refer to the [Autoware documen
   - Documentation repository for Autoware users and developers.
   - Since Autoware Core/Universe has multiple repositories, a central documentation repository is important to make information accessible from a single place.
 
+## Using Autoware.AI
+
+If you wish to use Autoware.AI, the previous version of Autoware based on ROS 1, switch to [autoware-ai](https://github.com/autowarefoundation/autoware.ai/tree/autoware-ai) branch. However, be aware that Autoware.AI will reach the end-of-life by the end of 2022, and we strongly recommend transitioning to Autoware Core/Universe for future use.
+
 ## Contributing
 
 - [There is no formal process to become a contributor](https://github.com/autowarefoundation/autoware-projects/wiki#contributors) - you can comment on any [existing issues](https://github.com/autowarefoundation/autoware.universe/issues) or make a pull request on any Autoware repository!

--- a/amd64.env
+++ b/amd64.env
@@ -1,6 +1,7 @@
 rosdistro=galactic
 rmw_implementation=rmw_cyclonedds_cpp
 base_image=ubuntu:20.04
+cuda_base_image=nvidia/cuda:11.4.3-devel-ubuntu20.04
 cuda_version=11.4
 cudnn_version=8.2.4.15-1+cuda11.4
 tensorrt_version=8.2.4-1+cuda11.4

--- a/ansible/playbooks/universe.yaml
+++ b/ansible/playbooks/universe.yaml
@@ -1,7 +1,7 @@
 - hosts: localhost
   connection: local
   vars_prompt:
-    - name: install_nvidia
+    - name: prompt_install_nvidia
       prompt: |-
         [Warning] Some Autoware components depend on the CUDA, cuDNN and TensorRT NVIDIA libraries which have end-user license agreements that should be reviewed before installation.
         Install NVIDIA libraries? [y/N]
@@ -20,7 +20,7 @@
         seconds: 10
         prompt: |
           [Warning] Skipping installation of NVIDIA libraries. Please manually install them if you plan to use any dependent components.
-      when: install_nvidia != 'y'
+      when: prompt_install_nvidia != 'y'
   roles:
     # Core
     - role: autoware.dev_env.autoware_core
@@ -34,8 +34,8 @@
     # Universe
     - role: autoware.dev_env.autoware_universe
     - role: autoware.dev_env.cuda
-      when: install_nvidia == 'y'
+      when: prompt_install_nvidia == 'y'
     - role: autoware.dev_env.pacmod
       when: rosdistro != 'rolling'
     - role: autoware.dev_env.tensorrt
-      when: install_nvidia == 'y'
+      when: prompt_install_nvidia == 'y'

--- a/ansible/roles/autoware_universe/meta/main.yaml
+++ b/ansible/roles/autoware_universe/meta/main.yaml
@@ -1,2 +1,2 @@
 dependencies:
-  - autoware_core
+  - role: autoware.dev_env.autoware_core

--- a/ansible/roles/cuda/tasks/main.yaml
+++ b/ansible/roles/cuda/tasks/main.yaml
@@ -41,7 +41,7 @@
     name:
       - cuda-drivers
     update_cache: true
-  when: install_cuda_drivers|bool
+  when: install_cuda_drivers | bool
 
 - name: Add PATH to .bashrc
   ansible.builtin.lineinfile:

--- a/ansible/roles/cuda/tasks/main.yaml
+++ b/ansible/roles/cuda/tasks/main.yaml
@@ -8,6 +8,12 @@
   register: cuda_architecture
   changed_when: false
 
+- name: Remove old /etc/apt/sources.list.d/cuda.list
+  become: true
+  ansible.builtin.file:
+    path: /etc/apt/sources.list.d/cuda.list
+    state: absent
+
 - name: Install CUDA keyring
   become: true
   ansible.builtin.apt:

--- a/ansible/roles/pacmod/meta/main.yaml
+++ b/ansible/roles/pacmod/meta/main.yaml
@@ -1,2 +1,2 @@
 dependencies:
-  - ros2
+  - role: autoware.dev_env.ros2

--- a/ansible/roles/plotjuggler/meta/main.yaml
+++ b/ansible/roles/plotjuggler/meta/main.yaml
@@ -1,2 +1,2 @@
 dependencies:
-  - ros2
+  - role: autoware.dev_env.ros2

--- a/ansible/roles/rmw_implementation/meta/main.yaml
+++ b/ansible/roles/rmw_implementation/meta/main.yaml
@@ -1,2 +1,2 @@
 dependencies:
-  - ros2
+  - role: autoware.dev_env.ros2

--- a/ansible/roles/ros2_dev_tools/meta/main.yaml
+++ b/ansible/roles/ros2_dev_tools/meta/main.yaml
@@ -1,2 +1,2 @@
 dependencies:
-  - ros2
+  - role: autoware.dev_env.ros2

--- a/ansible/roles/tensorrt/meta/main.yaml
+++ b/ansible/roles/tensorrt/meta/main.yaml
@@ -1,2 +1,2 @@
 dependencies:
-  - cuda
+  - role: autoware.dev_env.cuda

--- a/docker/autoware-universe/Dockerfile
+++ b/docker/autoware-universe/Dockerfile
@@ -3,58 +3,5 @@ ARG BASE_IMAGE
 FROM $BASE_IMAGE as devel
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-ARG ROS_DISTRO
-ARG SETUP_ARGS
-
-## Install apt packages
-# hadolint ignore=DL3008
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install --no-install-recommends \
-  git \
-  ssh \
-  && apt-get clean \
-  && rm -rf /var/lib/apt/lists/*
-
-## Copy files
-COPY autoware.repos setup-dev-env.sh ansible-galaxy-requirements.yaml amd64.env arm64.env /autoware/
-COPY ansible/ /autoware/ansible/
-WORKDIR /autoware
-RUN ls /autoware
-
-## Add GitHub to known hosts for private repositories
-RUN mkdir -p ~/.ssh \
-  && ssh-keyscan github.com >> ~/.ssh/known_hosts
-
-## Set up development environment
-RUN --mount=type=ssh \
-  ./setup-dev-env.sh -y $SETUP_ARGS universe \
-  && pip uninstall -y ansible ansible-core \
-  && mkdir src \
-  && vcs import src < autoware.repos \
-  && rosdep update \
-  && DEBIAN_FRONTEND=noninteractive rosdep install -y --ignore-src --from-paths src --rosdistro "$ROS_DISTRO" \
-  && apt-get clean \
-  && rm -rf /var/lib/apt/lists/*
-
-## Clean up unnecessary files
-RUN rm -rf \
-  "$HOME"/.cache \
-  /etc/apt/sources.list.d/cuda.list \
-  /etc/apt/sources.list.d/docker.list \
-  /etc/apt/sources.list.d/nvidia-docker.list
-
-## Create entrypoint
-# hadolint ignore=DL3059
-RUN echo "source /opt/ros/${ROS_DISTRO}/setup.bash" > /etc/bash.bashrc
-CMD ["/bin/bash"]
-
 FROM devel as prebuilt
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-
-## Build and change permission for runtime data conversion
-RUN source /opt/ros/"$ROS_DISTRO"/setup.bash \
-  && colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release \
-  && find /autoware/install -type d -exec chmod 777 {} \;
-
-## Create entrypoint
-RUN echo "source /autoware/install/setup.bash" > /etc/bash.bashrc
-CMD ["/bin/bash"]

--- a/setup-dev-env.sh
+++ b/setup-dev-env.sh
@@ -12,15 +12,19 @@ args=()
 while [ "$1" != "" ]; do
     case "$1" in
     -y)
+        # Use non-interactive mode.
         option_yes=true
         ;;
     -v)
+        # Enable debug outputs.
         option_verbose=true
         ;;
     --no-nvidia)
+        # Disable installation of the NVIDIA-related roles ('cuda' and 'tensorrt').
         option_no_nvidia=true
         ;;
     --no-cuda-drivers)
+        # Disable installation of 'cuda-drivers' in the role 'cuda'.
         option_no_cuda_drivers=true
         ;;
     *)
@@ -63,9 +67,9 @@ fi
 
 # Check installation of NVIDIA libraries
 if [ "$option_no_nvidia" = "true" ]; then
-    ansible_args+=("--extra-vars" "install_nvidia=n")
+    ansible_args+=("--extra-vars" "prompt_install_nvidia=n")
 elif [ "$option_yes" = "true" ]; then
-    ansible_args+=("--extra-vars" "install_nvidia=y")
+    ansible_args+=("--extra-vars" "prompt_install_nvidia=y")
 fi
 
 # Check installation of CUDA Drivers
@@ -114,10 +118,11 @@ fi
 export PATH="$HOME/.local/bin:$PATH"
 
 # Install ansible collections
+echo -e "\e[36m"ansible-galaxy collection install -f -r "$SCRIPT_DIR/ansible-galaxy-requirements.yaml" "\e[m"
 ansible-galaxy collection install -f -r "$SCRIPT_DIR/ansible-galaxy-requirements.yaml"
 
 # Run ansible
-echo -e "\e[36m Run ansible-playbook" "$target_playbook" "${ansible_args[@]}" "\e[m"
+echo -e "\e[36m"ansible-playbook "$target_playbook" "${ansible_args[@]}" "\e[m"
 if ansible-playbook "$target_playbook" "${ansible_args[@]}"; then
     echo -e "\e[32mCompleted.\e[0m"
     exit 0


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

It seems the issue was resolved. (But not released yet?)

![image](https://user-images.githubusercontent.com/31987104/169851627-5fd838d5-737d-47b6-8c4d-7b9c89c74113.png)

Related:
- https://github.com/docker/buildx/issues/756
- https://github.com/docker/buildx/pull/1025
- https://github.com/docker/bake-action/issues/61
- https://github.com/docker/metadata-action/issues/124#issuecomment-1018441005

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
