### PR TITLE
refactor: install cuda keyring package

### DIFF
--- a/ansible/roles/cuda/tasks/main.yaml
+++ b/ansible/roles/cuda/tasks/main.yaml
@@ -8,7 +8,7 @@
   register: cuda_architecture
   changed_when: false
 
-- name: Install cuda keyring
+- name: Install CUDA keyring
   ansible.builtin.apt:
     deb: https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/{{ cuda_architecture.stdout }}/cuda-keyring_1.0-1_all.deb
 

--- a/ansible/roles/cuda/tasks/main.yaml
+++ b/ansible/roles/cuda/tasks/main.yaml
@@ -8,23 +8,9 @@
   register: cuda_architecture
   changed_when: false
 
-- name: Download pin file
-  become: true
-  ansible.builtin.get_url:
-    url: https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/{{ cuda_architecture.stdout }}/cuda-ubuntu2004.pin
-    dest: /etc/apt/preferences.d/cuda-repository-pin-600
-
-- name: Add NVIDIA apt key
-  become: true
-  ansible.builtin.apt_key:
-    url: https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/{{ cuda_architecture.stdout }}/3bf863cc.pub
-
-- name: Add CUDA repository into sources.list
-  become: true
-  ansible.builtin.apt_repository:
-    repo: deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/{{ cuda_architecture.stdout }}/ /
-    filename: cuda
-    state: present
+- name: Install cuda keyring
+  ansible.builtin.apt:
+    deb: https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/{{ cuda_architecture.stdout }}/cuda-keyring_1.0-1_all.deb
 
 - name: Get dash-case name of cuda_version
   ansible.builtin.shell: bash -c 'sed -e "s/\./-/g" <<< $(echo {{ cuda_version }})'


### PR DESCRIPTION
## Description

https://developer.nvidia.com/blog/updating-the-cuda-linux-gpg-repository-key/

```
❯ dpkg -L cuda-keyring
/.
/etc
/etc/apt
/etc/apt/preferences.d
/etc/apt/preferences.d/cuda-repository-pin-600
/etc/apt/sources.list.d
/etc/apt/sources.list.d/cuda-ubuntu2004-x86_64.list
/usr
/usr/share
/usr/share/doc
/usr/share/doc/cuda-keyring
/usr/share/doc/cuda-keyring/changelog.Debian.gz
/usr/share/keyrings
/usr/share/keyrings/cuda-archive-keyring.gpg
```

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
