### PR TITLE
docs: update link to the support guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,4 +44,4 @@ To learn more about using or developing Autoware, refer to the [Autoware documen
 ## Useful resources
 
 - [Autoware Foundation homepage](https://www.autoware.org/)
-- [Support guidelines](https://autowarefoundation.github.io/autoware-documentation/main/help/support-guidelines/)
+- [Support guidelines](https://autowarefoundation.github.io/autoware-documentation/main/support/support-guidelines/)


### PR DESCRIPTION
It's updated by https://github.com/autowarefoundation/autoware-documentation/pull/91.