### PR TITLE
refactor(setup-dev-env.sh): make the target playbook configurable

### DIFF
--- a/setup-dev-env.sh
+++ b/setup-dev-env.sh
@@ -28,15 +28,10 @@ while [ "$1" != "" ]; do
 done
 
 # Select installation type
-installation_type=universe # default
+target_playbook="autoware.dev_env.universe" # default
 
 if [ ${#args[@]} -ge 1 ]; then
-    installation_type=${args[0]}
-fi
-
-if [ "$installation_type" != "core" ] && [ "$installation_type" != "universe" ] && [ "$installation_type" != "docker" ]; then
-    echo -e "\e[31mPlease input a valid installation type 'core', 'universe' or 'docker' as the 1st argument, or keep it empty to use the default.\e[m"
-    exit 1
+    target_playbook="autoware.dev_env.${args[0]}"
 fi
 
 # Initialize ansible args
@@ -105,8 +100,8 @@ fi
 ansible-galaxy collection install -f -r "$SCRIPT_DIR/ansible-galaxy-requirements.yaml"
 
 # Run ansible
-echo Run ansible-playbook "autoware.dev_env.$installation_type" "${ansible_args[@]}"
-if ansible-playbook "autoware.dev_env.$installation_type" "${ansible_args[@]}"; then
+echo -e "\e[36m Run ansible-playbook" "$target_playbook" "${ansible_args[@]}" "\e[m"
+if ansible-playbook "$target_playbook" "${ansible_args[@]}"; then
     echo -e "\e[32mCompleted.\e[0m"
     exit 0
 else


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

Considering that users fork this repository and customize the configurations depending on their system, it is useful to change the meaning of the argument.

With this change, users can do like the following:

```bash
# Add some roles for their system
vim ~/autoware.customized/ansible/roles
vim ~/autoware.customized/ansible/playbooks/customized_playbook.yaml

# Replace the base name
sed -e "s/autoware.dev_env/autoware_customized.dev_env/g" setup-dev-env.sh

# Call the playbook
./setup-dev-env.sh customized_playbook
```

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
