### PR TITLE
ci(github-release): fix verb selection

### DIFF
--- a/.github/workflows/github-release.yaml
+++ b/.github/workflows/github-release.yaml
@@ -54,7 +54,7 @@ jobs:
       - name: Select verb
         id: select-verb
         run: |
-          has_previous_draft=$(gh release view --json isDraft -q ".isDraft" "${{ steps.set-tag-name.outputs.tag-name }}")
+          has_previous_draft=$(gh release view --json isDraft -q ".isDraft" "${{ steps.set-tag-name.outputs.tag-name }}") || true
 
           verb=create
           if [ "$has_previous_draft" = "true" ]; then


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

There was a bug when there is no release yet.
https://github.com/autowarefoundation/autoware-github-actions/runs/6382495061?check_suite_focus=true

The test result is https://github.com/autowarefoundation/autoware-github-actions/runs/6382584760?check_suite_focus=true#step:7:13.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
