### PR TITLE
fix(setup): remove sudo for pip

### DIFF
--- a/ansible/roles/autoware_core/tasks/main.yaml
+++ b/ansible/roles/autoware_core/tasks/main.yaml
@@ -1,5 +1,4 @@
 - name: Install gdown to download files from CMakeLists.txt
-  become: true
   ansible.builtin.pip:
     name:
       - gdown

--- a/ansible/roles/plotjuggler/tasks/main.yaml
+++ b/ansible/roles/plotjuggler/tasks/main.yaml
@@ -1,6 +1,5 @@
 # Workaround for https://serverfault.com/questions/1099606/ansible-openssl-error-with-apt-module
 - name: Upgrade pyOpenSSL
-  become: true
   ansible.builtin.pip:
     name: pyOpenSSL
     state: latest

--- a/ansible/roles/pre_commit/tasks/main.yaml
+++ b/ansible/roles/pre_commit/tasks/main.yaml
@@ -1,12 +1,10 @@
 - name: Install pre-commit
-  become: true
   ansible.builtin.pip:
     name: pre-commit
     state: latest
     executable: pip3
 
 - name: Install clang-format
-  become: true
   ansible.builtin.pip:
     name: clang-format
     version: "{{ clang_format_version }}"

--- a/ansible/roles/ros2_dev_tools/tasks/main.yaml
+++ b/ansible/roles/ros2_dev_tools/tasks/main.yaml
@@ -18,7 +18,6 @@
     update_cache: true
 
 - name: Install pip packages
-  become: true
   ansible.builtin.pip:
     name:
       - flake8-blind-except

--- a/setup-dev-env.sh
+++ b/setup-dev-env.sh
@@ -102,6 +102,9 @@ if [ "$ansible_version" != "5" ]; then
     pip3 install -U "ansible==5.*"
 fi
 
+# For Python packages installed with user privileges
+export PATH="$HOME/.local/bin:$PATH"
+
 # Install ansible collections
 ansible-galaxy collection install -f -r "$SCRIPT_DIR/ansible-galaxy-requirements.yaml"
 

--- a/setup-dev-env.sh
+++ b/setup-dev-env.sh
@@ -99,7 +99,7 @@ fi
 ansible_version=$(pip3 list | grep -oP "^ansible\s+\K([0-9]+)" || true)
 if [ "$ansible_version" != "5" ]; then
     sudo apt-get -y purge ansible
-    sudo pip3 install -U "ansible==5.*"
+    pip3 install -U "ansible==5.*"
 fi
 
 # Install ansible collections


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

We've been using `sudo` for pip because, as written in `~/.profile`, `$HOME/.local/bin` isn't in the `$PATH` right after OS installation.

```bash
# set PATH so it includes user's private bin if it exists
if [ -d "$HOME/.local/bin" ] ; then
    PATH="$HOME/.local/bin:$PATH"
fi
```

However, using `sudo` for pip isn't recommended.

```sh-session
$ sudo pip install clang-format
[sudo] password for kenji: 
Requirement already satisfied: clang-format in /usr/local/lib/python3.10/dist-packages (14.0.1)
WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv
```

As I thought `sudo` can be removed if I add `export PATH="$HOME/.local/bin:$PATH"` in the setup script, I changed so.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
