### PR TITLE
feat(ansible): add ccache role

### DIFF
--- a/ansible/playbooks/core.yaml
+++ b/ansible/playbooks/core.yaml
@@ -8,6 +8,7 @@
           - rmw_implementation: "{{ rmw_implementation }}"
   roles:
     - role: autoware.dev_env.autoware_core
+    - role: autoware.dev_env.ccache
     - role: autoware.dev_env.plotjuggler
     - role: autoware.dev_env.pre_commit
     - role: autoware.dev_env.ros2

--- a/ansible/playbooks/universe.yaml
+++ b/ansible/playbooks/universe.yaml
@@ -24,6 +24,7 @@
   roles:
     # Core
     - role: autoware.dev_env.autoware_core
+    - role: autoware.dev_env.ccache
     - role: autoware.dev_env.plotjuggler
     - role: autoware.dev_env.pre_commit
     - role: autoware.dev_env.ros2

--- a/ansible/roles/ccache/README.md
+++ b/ansible/roles/ccache/README.md
@@ -1,0 +1,13 @@
+# ccache
+
+This role installs Ccache. You can access detailed information about Ccache with this [link](https://ccache.dev/).
+
+## Inputs
+
+None.
+
+## Manual Installation
+
+```bash
+sudo apt update && sudo apt install ccache
+```

--- a/ansible/roles/ccache/meta/main.yaml
+++ b/ansible/roles/ccache/meta/main.yaml
@@ -1,2 +1,0 @@
-dependencies:
-  - ros2

--- a/ansible/roles/ccache/meta/main.yaml
+++ b/ansible/roles/ccache/meta/main.yaml
@@ -1,0 +1,2 @@
+dependencies:
+  - ros2

--- a/ansible/roles/ccache/tasks/main.yaml
+++ b/ansible/roles/ccache/tasks/main.yaml
@@ -1,0 +1,7 @@
+- name: Install ccache
+  become: true
+  ansible.builtin.apt:
+    name:
+      - ccache
+    state: latest
+    update_cache: true


### PR DESCRIPTION
Signed-off-by: Berkay <berkay@leodrive.ai>

## Description

<!-- Write a brief description of this PR. -->
Closes ( autowarefoundation/autoware.ai#2442).

In autoware documentation page, [Ccache](https://ccache.dev/) is recommended to speed up recompilation. See [here](https://autowarefoundation.github.io/autoware-documentation/latest/how-to-guides/advanced-usage-of-colcon/#using-ccache). 

The purpose of this PR is adding Ccache into docker images.
## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
