### PR TITLE
chore(ansible/pacmod): limit pacmod role to run only with Galactic

### DIFF
--- a/ansible/playbooks/universe.yaml
+++ b/ansible/playbooks/universe.yaml
@@ -36,5 +36,6 @@
     - role: autoware.dev_env.cuda
       when: install_nvidia == 'y'
     - role: autoware.dev_env.pacmod
+      when: rosdistro == 'galactic'
     - role: autoware.dev_env.tensorrt
       when: install_nvidia == 'y'


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

Part of autowarefoundation/autoware#248.

It's not released for Humble yet, and won't be released for Rolling.
https://s3.amazonaws.com/autonomoustuff-repo/
https://github.com/astuff/pacmod3_msgs/issues/6#issuecomment-947710546

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
