### PR TITLE
feat: support ROS 2 Humble

### DIFF
--- a/.github/workflows/setup-docker.yaml
+++ b/.github/workflows/setup-docker.yaml
@@ -6,7 +6,7 @@ on:
 jobs:
   setup-docker:
     runs-on: ubuntu-latest
-    container: ubuntu:20.04
+    container: ubuntu:22.04
     steps:
       - name: Check out repository
         uses: actions/checkout@v3

--- a/.github/workflows/setup-universe.yaml
+++ b/.github/workflows/setup-universe.yaml
@@ -6,7 +6,7 @@ on:
 jobs:
   setup-universe:
     runs-on: ubuntu-latest
-    container: ubuntu:20.04
+    container: ubuntu:22.04
     steps:
       - name: Check out repository
         uses: actions/checkout@v3

--- a/.github/workflows/vcs-import.yaml
+++ b/.github/workflows/vcs-import.yaml
@@ -7,7 +7,7 @@ on:
 jobs:
   vcs-import:
     runs-on: ubuntu-latest
-    container: ros:galactic
+    container: ros:humble
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -20,7 +20,7 @@ jobs:
       - name: Register AutonomouStuff repository
         uses: autowarefoundation/autoware-github-actions/register-autonomoustuff-repository@v1
         with:
-          rosdistro: galactic
+          rosdistro: humble
 
       - name: Set git config
         uses: autowarefoundation/autoware-github-actions/set-git-config@v1
@@ -36,4 +36,4 @@ jobs:
         run: |
           sudo apt-get -y update
           rosdep update
-          DEBIAN_FRONTEND=noninteractive rosdep install -y --from-paths src --ignore-src --rosdistro galactic
+          DEBIAN_FRONTEND=noninteractive rosdep install -y --from-paths src --ignore-src --rosdistro humble

--- a/amd64.env
+++ b/amd64.env
@@ -1,6 +1,6 @@
 rosdistro=humble
 rmw_implementation=rmw_cyclonedds_cpp
-base_image=ubuntu:20.04
+base_image=ubuntu:22.04
 cuda_version=11.4
 cudnn_version=8.2.4.15-1+cuda11.4
 tensorrt_version=8.2.4-1+cuda11.4

--- a/amd64.env
+++ b/amd64.env
@@ -1,6 +1,7 @@
 rosdistro=humble
 rmw_implementation=rmw_cyclonedds_cpp
 base_image=ubuntu:22.04
+cuda_base_image=ubuntu:22.04
 cuda_version=11.6
 cudnn_version=8.4.0.27-1+cuda11.6
 tensorrt_version=8.2.4-1+cuda11.4

--- a/amd64.env
+++ b/amd64.env
@@ -1,6 +1,6 @@
 rosdistro=humble
 rmw_implementation=rmw_cyclonedds_cpp
 base_image=ubuntu:22.04
-cuda_version=11.4
-cudnn_version=8.2.4.15-1+cuda11.4
+cuda_version=11.6
+cudnn_version=8.4.0.27-1+cuda11.6
 tensorrt_version=8.2.4-1+cuda11.4

--- a/amd64.env
+++ b/amd64.env
@@ -1,4 +1,4 @@
-rosdistro=galactic
+rosdistro=humble
 rmw_implementation=rmw_cyclonedds_cpp
 base_image=ubuntu:20.04
 cuda_version=11.4

--- a/ansible/roles/cuda/tasks/main.yaml
+++ b/ansible/roles/cuda/tasks/main.yaml
@@ -8,6 +8,22 @@
   register: cuda_architecture
   changed_when: false
 
+- name: (tmp for Ubuntu 22.04) Add liburcu6 repository into sources.list for amd64
+  become: true
+  ansible.builtin.apt_repository:
+    repo: deb http://archive.ubuntu.com/ubuntu focal main restricted
+    filename: focal
+    state: present
+  when: cuda_architecture.stdout == "x86_64"
+
+- name: (tmp for Ubuntu 22.04) Add liburcu6 repository into sources.list for arm64
+  become: true
+  ansible.builtin.apt_repository:
+    repo: deb http://ports.ubuntu.com/ubuntu-ports focal main restricted
+    filename: focal
+    state: present
+  when: cuda_architecture.stdout == "aarch64"
+
 - name: Install CUDA keyring
   become: true
   ansible.builtin.apt:

--- a/ansible/roles/pacmod/README.md
+++ b/ansible/roles/pacmod/README.md
@@ -18,6 +18,6 @@ For Universe, the `rosdistro` variable can also be found in:
 sudo apt install apt-transport-https
 sudo sh -c 'echo "deb [trusted=yes] https://s3.amazonaws.com/autonomoustuff-repo/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/autonomoustuff-public.list'
 sudo apt update
-rosdistro=galactic
+rosdistro=humble
 sudo apt install ros-${rosdistro}-pacmod3
 ```

--- a/ansible/roles/plotjuggler/README.md
+++ b/ansible/roles/plotjuggler/README.md
@@ -10,5 +10,5 @@ None.
 
 ```bash
 sudo apt update && sudo apt install -y \
-  ros-galactic-plotjuggler-ros
+  ros-humble-plotjuggler-ros
 ```

--- a/ansible/roles/pre_commit/tasks/main.yaml
+++ b/ansible/roles/pre_commit/tasks/main.yaml
@@ -10,12 +10,6 @@
     version: "{{ clang_format_version }}"
     executable: pip3
 
-# TODO: Remove after we move to Ubuntu 22.04
-- name: Add Go PPA for shfmt
-  become: true
-  ansible.builtin.apt_repository:
-    repo: ppa:longsleep/golang-backports # cspell:disable-line
-
 - name: Install Go
   become: true
   ansible.builtin.apt:

--- a/ansible/roles/rmw_implementation/README.md
+++ b/ansible/roles/rmw_implementation/README.md
@@ -1,6 +1,6 @@
 # rmw_implementation
 
-This role sets up ROS 2 RMW implementation following [this page](https://docs.ros.org/en/galactic/How-To-Guides/Working-with-multiple-RMW-implementations.html).
+This role sets up ROS 2 RMW implementation following [this page](https://docs.ros.org/en/rolling/How-To-Guides/Working-with-multiple-RMW-implementations.html).
 
 ## Inputs
 
@@ -15,9 +15,11 @@ For Universe, the `rosdistro` and `rmw_implementation` variable can also be foun
 [../../playbooks/universe.yaml](../../playbooks/universe.yaml)
 
 ```bash
-# For details: https://docs.ros.org/en/galactic/How-To-Guides/Working-with-multiple-RMW-implementations.html
+# For details: https://docs.ros.org/en/humble/How-To-Guides/Working-with-multiple-RMW-implementations.html
+wget -O /tmp/amd64.env https://raw.githubusercontent.com/autowarefoundation/autoware/main/amd64.env && source /tmp/amd64.env
+
 sudo apt update
-rosdistro=galactic
+rosdistro=humble
 rmw_implementation=rmw_cyclonedds_cpp
 rmw_implementation_dashed=$(eval sed -e "s/_/-/g" <<< "${rmw_implementation}")
 sudo apt install ros-${rosdistro}-${rmw_implementation_dashed}

--- a/ansible/roles/ros2/README.md
+++ b/ansible/roles/ros2/README.md
@@ -1,6 +1,6 @@
 # ros2
 
-This role installs [ROS 2](http://www.ros2.org/) following [this page](https://docs.ros.org/en/galactic/Installation/Ubuntu-Install-Debians.html).
+This role installs [ROS 2](http://www.ros2.org/) following [this page](https://docs.ros.org/en/rolling/Installation/Ubuntu-Install-Debians.html).
 
 Additional steps may be needed depending on the `rosdistro` you choose.
 
@@ -30,7 +30,7 @@ For Universe, the `rosdistro` variable can also be found in:
 [../../playbooks/universe.yaml](../../playbooks/universe.yaml)
 
 ```bash
-# Taken from: https://docs.ros.org/en/galactic/Installation/Ubuntu-Install-Debians.html
+# Taken from: https://docs.ros.org/en/humble/Installation/Ubuntu-Install-Debians.html
 
 # You will need to add the ROS 2 apt repository to your system. First, make sure that the Ubuntu Universe repository is enabled by checking the output of this command.
 apt-cache policy | grep universe
@@ -55,7 +55,7 @@ echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-a
 sudo apt update
 
 # Desktop Install
-rosdistro=galactic
+rosdistro=humble
 installation_type=desktop
 sudo apt install ros-${rosdistro}-${installation_type}
 

--- a/ansible/roles/ros2_dev_tools/README.md
+++ b/ansible/roles/ros2_dev_tools/README.md
@@ -1,6 +1,6 @@
 # ros2_dev_tools
 
-This role installs ROS 2 development tools following [this page](https://docs.ros.org/en/galactic/Installation/Ubuntu-Development-Setup.html).
+This role installs ROS 2 development tools following [this page](https://docs.ros.org/en/humble/Installation/Ubuntu-Development-Setup.html).
 
 ## Inputs
 
@@ -9,7 +9,7 @@ None.
 ## Manual Installation
 
 ```bash
-# Taken from https://docs.ros.org/en/galactic/Installation/Ubuntu-Development-Setup.html
+# Taken from https://docs.ros.org/en/humble/Installation/Ubuntu-Development-Setup.html
 sudo apt update && sudo apt install -y \
   build-essential \
   cmake \

--- a/arm64.env
+++ b/arm64.env
@@ -1,2 +1,1 @@
 # Override amd64's settings
-cudnn_version=8.2.4.12-1+cuda11.4

--- a/autoware.repos
+++ b/autoware.repos
@@ -16,6 +16,10 @@ repositories:
     type: git
     url: https://github.com/tier4/autoware_auto_msgs.git
     version: tier4/main
+  core/external/ament_cmake:
+    type: git
+    url: https://github.com/autowarefoundation/ament_cmake.git
+    version: autoware-humble
   # universe
   universe/autoware.universe:
     type: git

--- a/autoware.repos
+++ b/autoware.repos
@@ -36,7 +36,7 @@ repositories:
   universe/external/grid_map:
     type: git
     url: https://github.com/ANYbotics/grid_map.git
-    version: ba2f9cb6e62f7ee9c5bac7401391a211e442e459
+    version: 74333f037cfce321248dfa7b954a815d4f67d79d
   universe/external/muSSP:
     type: git
     url: https://github.com/tier4/muSSP.git


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

Resolves autowarefoundation/autoware.ai#2443.

I won't merge this PR to `main` until `Galactic` support by the AWF ends.
Users have to switch branches if they want to use `Humble` because it would be too complex if we support both distros in one branch.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
