### PR TITLE
ci(docker): add rosdistro to image names

### DIFF
--- a/.github/actions/docker-build-and-push/action.yaml
+++ b/.github/actions/docker-build-and-push/action.yaml
@@ -8,6 +8,9 @@ inputs:
   build-args:
     description: ""
     required: false
+  tag-prefix:
+    description: ""
+    required: false
   tag-suffix:
     description: ""
     required: false
@@ -59,6 +62,7 @@ runs:
         bake-target: docker-metadata-action-devel
         flavor: |
           latest=false
+          prefix=${{ inputs.tag-prefix }}
           suffix=${{ inputs.tag-suffix }}
 
     - name: Docker meta for prebuilt
@@ -70,6 +74,7 @@ runs:
         bake-target: docker-metadata-action-prebuilt
         flavor: |
           latest=false
+          prefix=${{ inputs.tag-prefix }}
           suffix=-prebuilt${{ inputs.tag-suffix }}
 
     - name: Login to GitHub Container Registry

--- a/.github/workflows/docker-build-and-push.yaml
+++ b/.github/workflows/docker-build-and-push.yaml
@@ -35,6 +35,7 @@ jobs:
             *.args.CUDA_IMAGE_TAG=${{ env.cuda_image_tag }}
             *.args.CUDNN_VERSION=${{ env.cudnn_version }}
             *.args.TENSORRT_VERSION=${{ env.tensorrt_version }}
+          tag-prefix: ${{ env.rosdistro }}-
           tag-suffix: -amd64
 
       - name: Show disk space

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -21,5 +21,5 @@ docker buildx bake --load --progress=plain -f "$SCRIPT_DIR/autoware-universe/doc
     --set "*.args.CUDA_IMAGE_TAG=$cuda_image_tag" \
     --set "*.args.CUDNN_VERSION=$cudnn_version" \
     --set "*.args.TENSORRT_VERSION=$tensorrt_version" \
-    --set "devel.tags=ghcr.io/autowarefoundation/autoware-universe:latest" \
-    --set "prebuilt.tags=ghcr.io/autowarefoundation/autoware-universe:latest-prebuilt"
+    --set "devel.tags=ghcr.io/autowarefoundation/autoware-universe:$rosdistro-latest" \
+    --set "prebuilt.tags=ghcr.io/autowarefoundation/autoware-universe:$rosdistro-latest-prebuilt"


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

To support both Galactic and Humble, I'd like to add `rosdistro` to Docker image names.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
