### PR TITLE
feat(setup, ansible): add an option for not installing cuda-drivers

### DIFF
--- a/ansible/roles/cuda/README.md
+++ b/ansible/roles/cuda/README.md
@@ -4,9 +4,10 @@ This role installs [CUDA Toolkit](https://developer.nvidia.com/cuda-toolkit) fol
 
 ## Inputs
 
-| Name         | Required | Description                  |
-| ------------ | -------- | ---------------------------- |
-| cuda_version | true     | The version of CUDA Toolkit. |
+| Name                 | Required | Description                      |
+| -------------------- | -------- | -------------------------------- |
+| cuda_version         | true     | The version of CUDA Toolkit.     |
+| install_cuda_drivers | false    | Whether to install cuda-drivers. |
 
 ## Manual Installation
 

--- a/ansible/roles/cuda/defaults/main.yaml
+++ b/ansible/roles/cuda/defaults/main.yaml
@@ -1,0 +1,1 @@
+install_cuda_drivers: true

--- a/ansible/roles/cuda/tasks/main.yaml
+++ b/ansible/roles/cuda/tasks/main.yaml
@@ -19,11 +19,20 @@
   register: dash_case_cuda_version
   changed_when: false
 
-- name: Install cuda-{{ dash_case_cuda_version.stdout }}
+- name: Install cuda-toolkit-{{ dash_case_cuda_version.stdout }}
   become: true
   ansible.builtin.apt:
-    name: cuda-{{ dash_case_cuda_version.stdout }}
+    name:
+      - cuda-toolkit-{{ dash_case_cuda_version.stdout }}
     update_cache: true
+
+- name: Install cuda-drivers
+  become: true
+  ansible.builtin.apt:
+    name:
+      - cuda-drivers
+    update_cache: true
+  when: install_cuda_drivers|bool
 
 - name: Add PATH to .bashrc
   ansible.builtin.lineinfile:

--- a/setup-dev-env.sh
+++ b/setup-dev-env.sh
@@ -20,6 +20,9 @@ while [ "$1" != "" ]; do
     --no-nvidia)
         option_no_nvidia=true
         ;;
+    --no-cuda-drivers)
+        option_no_cuda_drivers=true
+        ;;
     *)
         args+=("$1")
         ;;
@@ -58,11 +61,16 @@ if [ "$option_verbose" = "true" ]; then
     ansible_args+=("-vvv")
 fi
 
-# Check NVIDIA Installation
+# Check installation of NVIDIA libraries
 if [ "$option_no_nvidia" = "true" ]; then
     ansible_args+=("--extra-vars" "install_nvidia=n")
 elif [ "$option_yes" = "true" ]; then
     ansible_args+=("--extra-vars" "install_nvidia=y")
+fi
+
+# Check installation of CUDA Drivers
+if [ "$option_no_cuda_drivers" = "true" ]; then
+    ansible_args+=("--extra-vars" "install_cuda_drivers=false")
 fi
 
 # Load env


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

According to https://docs.nvidia.com/cuda/eula/index.html#attachment-a, only `cuda-drivers` have different requirements for redistribution.

> The NVIDIA CUDA Driver Libraries are only distributable in applications that meet this criteria:
> 1. The application was developed starting from a NVIDIA CUDA container obtained from Docker Hub or the NVIDIA GPU Cloud, and
> 2. The resulting application is packaged as a Docker container and distributed to users on Docker Hub or the NVIDIA GPU Cloud only.

I'd like to add an option to install `cuda-drivers` or not for more flexibility.

The explanation for each meta-package is here: https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html#package-manager-metas

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
