### PR TITLE
fix(ansible/cuda): select packages to install

### DIFF
--- a/ansible/roles/cuda/tasks/main.yaml
+++ b/ansible/roles/cuda/tasks/main.yaml
@@ -19,11 +19,20 @@
   register: dash_case_cuda_version
   changed_when: false
 
-- name: Install cuda-toolkit-{{ dash_case_cuda_version.stdout }}
+- name: Install CUDA libraries except for cuda-drivers
   become: true
   ansible.builtin.apt:
     name:
-      - cuda-toolkit-{{ dash_case_cuda_version.stdout }}
+      - cuda-cudart-dev-{{ dash_case_cuda_version.stdout }}
+      - cuda-command-line-tools-{{ dash_case_cuda_version.stdout }}
+      - cuda-minimal-build-{{ dash_case_cuda_version.stdout }}
+      - cuda-libraries-dev-{{ dash_case_cuda_version.stdout }}
+      - cuda-nvml-dev-{{ dash_case_cuda_version.stdout }}
+      - cuda-nvprof-{{ dash_case_cuda_version.stdout }}
+      - libnpp-dev-{{ dash_case_cuda_version.stdout }}
+      - libcusparse-dev-{{ dash_case_cuda_version.stdout }}
+      - libcublas-dev-{{ dash_case_cuda_version.stdout }}
+      - libnccl-dev
     update_cache: true
 
 - name: Install cuda-drivers


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

Resolves autowarefoundation/autoware.ai#2444

Select the packages to install according to https://gitlab.com/nvidia/container-images/cuda/-/blob/master/dist/11.6.2/ubuntu2004/devel/Dockerfile#L56.

`cuda-minimal-build` and `libnccl-dev` weren't installed in my environment (installed `cuda-11-6`).

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
