### PR TITLE
ci(create-main-distro-alias): fix typo

### DIFF
--- a/.github/actions/create-main-distro-alias/action.yaml
+++ b/.github/actions/create-main-distro-alias/action.yaml
@@ -53,7 +53,7 @@ runs:
           amd64_image="$distro_image-amd64"
         fi
         if docker manifest inspect "$distro_image-arm64" >/dev/null 2>&1; then
-          amd64_image="$distro_image-arm64"
+          arm64_image="$distro_image-arm64"
         fi
 
         echo "amd64_image: $amd64_image"

--- a/.github/actions/create-main-distro-alias/action.yaml
+++ b/.github/actions/create-main-distro-alias/action.yaml
@@ -32,7 +32,7 @@ runs:
           amd64_image="$distro_image-amd64"
         fi
         if docker manifest inspect "$distro_image-arm64" >/dev/null 2>&1; then
-          amd64_image="$distro_image-arm64"
+          arm64_image="$distro_image-arm64"
         fi
 
         echo "amd64_image: $amd64_image"


### PR DESCRIPTION
`amd64_image` was mistakenly overwritten. :disappointed: 
https://github.com/autowarefoundation/autoware/runs/6566482035?check_suite_focus=true#step:4:66