### PR TITLE
ci(docker-build-and-push): use matrix CI for no-CUDA and CUDA images

### DIFF
--- a/.github/workflows/docker-build-and-push-humble-self-hosted.yaml
+++ b/.github/workflows/docker-build-and-push-humble-self-hosted.yaml
@@ -14,9 +14,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        name:
+          - no-cuda
+          - cuda
         include:
-          - { setup-args: --no-nvidia, additional-tag-suffix: "" }
-          - { setup-args: --no-cuda-drivers, additional-tag-suffix: -cuda }
+          - { name: no-cuda, setup-args: --no-nvidia, additional-tag-suffix: "" }
+          - { name: cuda, setup-args: --no-cuda-drivers, additional-tag-suffix: -cuda }
     steps:
       # https://github.com/actions/checkout/issues/211
       - name: Change permission of workspace

--- a/.github/workflows/docker-build-and-push-humble-self-hosted.yaml
+++ b/.github/workflows/docker-build-and-push-humble-self-hosted.yaml
@@ -11,6 +11,12 @@ on:
 jobs:
   docker-build-and-push-humble-self-hosted:
     runs-on: [self-hosted, linux, ARM64]
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { setup-args: --no-nvidia, additional-tag-prefix: "" }
+          - { setup-args: --no-cuda-drivers, additional-tag-prefix: cuda- }
     steps:
       # https://github.com/actions/checkout/issues/211
       - name: Change permission of workspace
@@ -32,7 +38,7 @@ jobs:
             cat arm64.env | sed -e "s/^\s*//" -e "/^#/d" >> $GITHUB_ENV
           fi
 
-      - name: Build 'autoware-universe' without CUDA
+      - name: Build 'autoware-universe'
         uses: ./.github/actions/docker-build-and-push
         with:
           bake-target: autoware-universe
@@ -40,20 +46,8 @@ jobs:
             *.platform=linux/arm64
             *.args.ROS_DISTRO=${{ env.rosdistro }}
             *.args.BASE_IMAGE=${{ env.base_image }}
-            *.args.SETUP_ARGS=--no-nvidia
-          tag-prefix: ${{ env.rosdistro }}-
-          tag-suffix: -arm64
-
-      - name: Build 'autoware-universe' with CUDA
-        uses: ./.github/actions/docker-build-and-push
-        with:
-          bake-target: autoware-universe
-          build-args: |
-            *.platform=linux/amd64
-            *.args.ROS_DISTRO=${{ env.rosdistro }}
-            *.args.BASE_IMAGE=${{ env.base_image }}
-            *.args.SETUP_ARGS=--no-cuda-drivers
-          tag-prefix: ${{ env.rosdistro }}-cuda-
+            *.args.SETUP_ARGS=${{ matrix.setup-args }}
+          tag-prefix: ${{ env.rosdistro }}-${{ matrix.additional-tag-prefix }}
           tag-suffix: -arm64
 
       - name: Show disk space

--- a/.github/workflows/docker-build-and-push-humble-self-hosted.yaml
+++ b/.github/workflows/docker-build-and-push-humble-self-hosted.yaml
@@ -15,8 +15,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { setup-args: --no-nvidia, additional-tag-prefix: "" }
-          - { setup-args: --no-cuda-drivers, additional-tag-prefix: cuda- }
+          - { setup-args: --no-nvidia, additional-tag-suffix: "" }
+          - { setup-args: --no-cuda-drivers, additional-tag-suffix: -cuda }
     steps:
       # https://github.com/actions/checkout/issues/211
       - name: Change permission of workspace
@@ -47,8 +47,8 @@ jobs:
             *.args.ROS_DISTRO=${{ env.rosdistro }}
             *.args.BASE_IMAGE=${{ env.base_image }}
             *.args.SETUP_ARGS=${{ matrix.setup-args }}
-          tag-prefix: ${{ env.rosdistro }}-${{ matrix.additional-tag-prefix }}
-          tag-suffix: -arm64
+          tag-prefix: ${{ env.rosdistro }}-
+          tag-suffix: ${{ matrix.additional-tag-suffix }}-arm64
 
       - name: Show disk space
         run: |

--- a/.github/workflows/docker-build-and-push-humble.yaml
+++ b/.github/workflows/docker-build-and-push-humble.yaml
@@ -15,8 +15,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { setup-args: --no-nvidia, additional-tag-prefix: "" }
-          - { setup-args: --no-cuda-drivers, additional-tag-prefix: cuda- }
+          - { setup-args: --no-nvidia, additional-tag-suffix: "" }
+          - { setup-args: --no-cuda-drivers, additional-tag-suffix: -cuda }
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -42,8 +42,8 @@ jobs:
             *.args.ROS_DISTRO=${{ env.rosdistro }}
             *.args.BASE_IMAGE=${{ env.base_image }}
             *.args.SETUP_ARGS=${{ matrix.setup-args }}
-          tag-prefix: ${{ env.rosdistro }}-${{ matrix.additional-tag-prefix }}
-          tag-suffix: -amd64
+          tag-prefix: ${{ env.rosdistro }}-
+          tag-suffix: ${{ matrix.additional-tag-suffix }}-amd64
 
       - name: Show disk space
         run: |

--- a/.github/workflows/docker-build-and-push-humble.yaml
+++ b/.github/workflows/docker-build-and-push-humble.yaml
@@ -14,9 +14,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        name:
+          - no-cuda
+          - cuda
         include:
-          - { setup-args: --no-nvidia, additional-tag-suffix: "" }
-          - { setup-args: --no-cuda-drivers, additional-tag-suffix: -cuda }
+          - { name: no-cuda, setup-args: --no-nvidia, additional-tag-suffix: "" }
+          - { name: cuda, setup-args: --no-cuda-drivers, additional-tag-suffix: -cuda }
     steps:
       - name: Check out repository
         uses: actions/checkout@v3

--- a/.github/workflows/docker-build-and-push-humble.yaml
+++ b/.github/workflows/docker-build-and-push-humble.yaml
@@ -11,6 +11,12 @@ on:
 jobs:
   docker-build-and-push-humble:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { setup-args: --no-nvidia, additional-tag-prefix: "" }
+          - { setup-args: --no-cuda-drivers, additional-tag-prefix: cuda- }
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -27,7 +33,7 @@ jobs:
             cat arm64.env | sed -e "s/^\s*//" -e "/^#/d" >> $GITHUB_ENV
           fi
 
-      - name: Build 'autoware-universe' without CUDA
+      - name: Build 'autoware-universe'
         uses: ./.github/actions/docker-build-and-push
         with:
           bake-target: autoware-universe
@@ -35,20 +41,8 @@ jobs:
             *.platform=linux/amd64
             *.args.ROS_DISTRO=${{ env.rosdistro }}
             *.args.BASE_IMAGE=${{ env.base_image }}
-            *.args.SETUP_ARGS=--no-nvidia
-          tag-prefix: ${{ env.rosdistro }}-
-          tag-suffix: -amd64
-
-      - name: Build 'autoware-universe' with CUDA
-        uses: ./.github/actions/docker-build-and-push
-        with:
-          bake-target: autoware-universe
-          build-args: |
-            *.platform=linux/amd64
-            *.args.ROS_DISTRO=${{ env.rosdistro }}
-            *.args.BASE_IMAGE=${{ env.base_image }}
-            *.args.SETUP_ARGS=--no-cuda-drivers
-          tag-prefix: ${{ env.rosdistro }}-cuda-
+            *.args.SETUP_ARGS=${{ matrix.setup-args }}
+          tag-prefix: ${{ env.rosdistro }}-${{ matrix.additional-tag-prefix }}
           tag-suffix: -amd64
 
       - name: Show disk space

--- a/.github/workflows/docker-build-and-push-main-self-hosted.yaml
+++ b/.github/workflows/docker-build-and-push-main-self-hosted.yaml
@@ -14,9 +14,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        name:
+          - no-cuda
+          - cuda
         include:
-          - { setup-args: --no-nvidia, additional-tag-suffix: "" }
-          - { setup-args: --no-cuda-drivers, additional-tag-suffix: -cuda }
+          - { name: no-cuda, setup-args: --no-nvidia, additional-tag-suffix: "" }
+          - { name: cuda, setup-args: --no-cuda-drivers, additional-tag-suffix: -cuda }
     steps:
       # https://github.com/actions/checkout/issues/211
       - name: Change permission of workspace

--- a/.github/workflows/docker-build-and-push-main-self-hosted.yaml
+++ b/.github/workflows/docker-build-and-push-main-self-hosted.yaml
@@ -11,6 +11,12 @@ on:
 jobs:
   docker-build-and-push-main-self-hosted:
     runs-on: [self-hosted, linux, ARM64]
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { setup-args: --no-nvidia, additional-tag-prefix: "" }
+          - { setup-args: --no-cuda-drivers, additional-tag-prefix: cuda- }
     steps:
       # https://github.com/actions/checkout/issues/211
       - name: Change permission of workspace
@@ -32,7 +38,7 @@ jobs:
             cat arm64.env | sed -e "s/^\s*//" -e "/^#/d" >> $GITHUB_ENV
           fi
 
-      - name: Build 'autoware-universe' without CUDA
+      - name: Build 'autoware-universe'
         uses: ./.github/actions/docker-build-and-push
         with:
           bake-target: autoware-universe
@@ -40,20 +46,8 @@ jobs:
             *.platform=linux/arm64
             *.args.ROS_DISTRO=${{ env.rosdistro }}
             *.args.BASE_IMAGE=${{ env.base_image }}
-            *.args.SETUP_ARGS=--no-nvidia
-          tag-prefix: ${{ env.rosdistro }}-
-          tag-suffix: -arm64
-
-      - name: Build 'autoware-universe' with CUDA
-        uses: ./.github/actions/docker-build-and-push
-        with:
-          bake-target: autoware-universe
-          build-args: |
-            *.platform=linux/amd64
-            *.args.ROS_DISTRO=${{ env.rosdistro }}
-            *.args.BASE_IMAGE=${{ env.base_image }}
-            *.args.SETUP_ARGS=--no-cuda-drivers
-          tag-prefix: ${{ env.rosdistro }}-cuda-
+            *.args.SETUP_ARGS=${{ matrix.setup-args }}
+          tag-prefix: ${{ env.rosdistro }}-${{ matrix.additional-tag-prefix }}
           tag-suffix: -arm64
 
       - name: Show disk space

--- a/.github/workflows/docker-build-and-push-main-self-hosted.yaml
+++ b/.github/workflows/docker-build-and-push-main-self-hosted.yaml
@@ -15,8 +15,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { setup-args: --no-nvidia, additional-tag-prefix: "" }
-          - { setup-args: --no-cuda-drivers, additional-tag-prefix: cuda- }
+          - { setup-args: --no-nvidia, additional-tag-suffix: "" }
+          - { setup-args: --no-cuda-drivers, additional-tag-suffix: -cuda }
     steps:
       # https://github.com/actions/checkout/issues/211
       - name: Change permission of workspace
@@ -47,8 +47,8 @@ jobs:
             *.args.ROS_DISTRO=${{ env.rosdistro }}
             *.args.BASE_IMAGE=${{ env.base_image }}
             *.args.SETUP_ARGS=${{ matrix.setup-args }}
-          tag-prefix: ${{ env.rosdistro }}-${{ matrix.additional-tag-prefix }}
-          tag-suffix: -arm64
+          tag-prefix: ${{ env.rosdistro }}-
+          tag-suffix: ${{ matrix.additional-tag-suffix }}-arm64
 
       - name: Show disk space
         run: |

--- a/.github/workflows/docker-build-and-push-main.yaml
+++ b/.github/workflows/docker-build-and-push-main.yaml
@@ -15,8 +15,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { setup-args: --no-nvidia, additional-tag-prefix: "" }
-          - { setup-args: --no-cuda-drivers, additional-tag-prefix: cuda- }
+          - { setup-args: --no-nvidia, additional-tag-suffix: "" }
+          - { setup-args: --no-cuda-drivers, additional-tag-suffix: -cuda }
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -42,8 +42,8 @@ jobs:
             *.args.ROS_DISTRO=${{ env.rosdistro }}
             *.args.BASE_IMAGE=${{ env.base_image }}
             *.args.SETUP_ARGS=${{ matrix.setup-args }}
-          tag-prefix: ${{ env.rosdistro }}-${{ matrix.additional-tag-prefix }}
-          tag-suffix: -amd64
+          tag-prefix: ${{ env.rosdistro }}-
+          tag-suffix: ${{ matrix.additional-tag-suffix }}-amd64
 
       - name: Show disk space
         run: |

--- a/.github/workflows/docker-build-and-push-main.yaml
+++ b/.github/workflows/docker-build-and-push-main.yaml
@@ -14,9 +14,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        name:
+          - no-cuda
+          - cuda
         include:
-          - { setup-args: --no-nvidia, additional-tag-suffix: "" }
-          - { setup-args: --no-cuda-drivers, additional-tag-suffix: -cuda }
+          - { name: no-cuda, setup-args: --no-nvidia, additional-tag-suffix: "" }
+          - { name: cuda, setup-args: --no-cuda-drivers, additional-tag-suffix: -cuda }
     steps:
       - name: Check out repository
         uses: actions/checkout@v3

--- a/.github/workflows/docker-build-and-push-main.yaml
+++ b/.github/workflows/docker-build-and-push-main.yaml
@@ -11,6 +11,12 @@ on:
 jobs:
   docker-build-and-push-main:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { setup-args: --no-nvidia, additional-tag-prefix: "" }
+          - { setup-args: --no-cuda-drivers, additional-tag-prefix: cuda- }
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -27,7 +33,7 @@ jobs:
             cat arm64.env | sed -e "s/^\s*//" -e "/^#/d" >> $GITHUB_ENV
           fi
 
-      - name: Build 'autoware-universe' without CUDA
+      - name: Build 'autoware-universe'
         uses: ./.github/actions/docker-build-and-push
         with:
           bake-target: autoware-universe
@@ -35,20 +41,8 @@ jobs:
             *.platform=linux/amd64
             *.args.ROS_DISTRO=${{ env.rosdistro }}
             *.args.BASE_IMAGE=${{ env.base_image }}
-            *.args.SETUP_ARGS=--no-nvidia
-          tag-prefix: ${{ env.rosdistro }}-
-          tag-suffix: -amd64
-
-      - name: Build 'autoware-universe' with CUDA
-        uses: ./.github/actions/docker-build-and-push
-        with:
-          bake-target: autoware-universe
-          build-args: |
-            *.platform=linux/amd64
-            *.args.ROS_DISTRO=${{ env.rosdistro }}
-            *.args.BASE_IMAGE=${{ env.base_image }}
-            *.args.SETUP_ARGS=--no-cuda-drivers
-          tag-prefix: ${{ env.rosdistro }}-cuda-
+            *.args.SETUP_ARGS=${{ matrix.setup-args }}
+          tag-prefix: ${{ env.rosdistro }}-${{ matrix.additional-tag-prefix }}
           tag-suffix: -amd64
 
       - name: Show disk space


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

- To remove duplicates
- To run parallel
- To resolve errors on ARM self-hosted machine
  - https://github.com/autowarefoundation/autoware/runs/6566418933?check_suite_focus=true#step:7:1110

The `cuda-` prefix was changed to the `-cuda` suffix for #355.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
