### PR TITLE
ci(update-docker-manifest): create aliases for CUDA images

### DIFF
--- a/.github/actions/create-main-distro-alias/action.yaml
+++ b/.github/actions/create-main-distro-alias/action.yaml
@@ -8,6 +8,9 @@ inputs:
   rosdistro:
     description: ""
     required: true
+  tag-name:
+    description: ""
+    required: true
 
 runs:
   using: composite
@@ -27,7 +30,7 @@ runs:
     - name: Create Docker manifest for latest
       run: |
         # Check image existence
-        distro_image="${{ steps.set-image-name.outputs.image-name }}:${{ inputs.rosdistro }}-latest"
+        distro_image="${{ steps.set-image-name.outputs.image-name }}:${{ inputs.rosdistro }}-${{ inputs.tag-name }}"
         if docker manifest inspect "$distro_image-amd64" >/dev/null 2>&1; then
           amd64_image="$distro_image-amd64"
         fi
@@ -38,30 +41,9 @@ runs:
         echo "amd64_image: $amd64_image"
         echo "arm64_image: $arm64_image"
 
-        docker manifest create --amend ${{ steps.set-image-name.outputs.image-name }}:latest \
+        docker manifest create --amend ${{ steps.set-image-name.outputs.image-name }}:${{ inputs.tag-name }} \
           $amd64_image \
           $arm64_image
 
-        docker manifest push ${{ steps.set-image-name.outputs.image-name }}:latest
-      shell: bash
-
-    - name: Create Docker manifest for latest-prebuilt
-      run: |
-        # Check image existence
-        distro_image="${{ steps.set-image-name.outputs.image-name }}:${{ inputs.rosdistro }}-latest-prebuilt"
-        if docker manifest inspect "$distro_image-amd64" >/dev/null 2>&1; then
-          amd64_image="$distro_image-amd64"
-        fi
-        if docker manifest inspect "$distro_image-arm64" >/dev/null 2>&1; then
-          arm64_image="$distro_image-arm64"
-        fi
-
-        echo "amd64_image: $amd64_image"
-        echo "arm64_image: $arm64_image"
-
-        docker manifest create --amend ${{ steps.set-image-name.outputs.image-name }}:latest-prebuilt \
-          $amd64_image \
-          $arm64_image
-
-        docker manifest push ${{ steps.set-image-name.outputs.image-name }}:latest-prebuilt
+        docker manifest push ${{ steps.set-image-name.outputs.image-name }}:${{ inputs.tag-name }}
       shell: bash

--- a/.github/workflows/update-docker-manifest.yaml
+++ b/.github/workflows/update-docker-manifest.yaml
@@ -17,8 +17,30 @@ jobs:
         with:
           package-name: autoware-universe
 
-      - name: Create main distro alias for 'autoware-universe'
+      - name: Create alias from 'autoware-universe:{rosdistro}-latest' to 'autoware-universe:latest'
         uses: ./.github/actions/create-main-distro-alias
         with:
           package-name: autoware-universe
           rosdistro: galactic
+          tag-name: latest
+
+      - name: Create alias from 'autoware-universe:{rosdistro}-latest-prebuilt' to 'autoware-universe:latest-prebuilt'
+        uses: ./.github/actions/create-main-distro-alias
+        with:
+          package-name: autoware-universe
+          rosdistro: galactic
+          tag-name: latest-prebuilt
+
+      - name: Create alias from 'autoware-universe:{rosdistro}-latest-cuda' to 'autoware-universe:latest-cuda'
+        uses: ./.github/actions/create-main-distro-alias
+        with:
+          package-name: autoware-universe
+          rosdistro: galactic
+          tag-name: latest-cuda
+
+      - name: Create alias from 'autoware-universe:{rosdistro}-latest-cuda-prebuilt' to 'autoware-universe:latest-cuda-prebuilt'
+        uses: ./.github/actions/create-main-distro-alias
+        with:
+          package-name: autoware-universe
+          rosdistro: galactic
+          tag-name: latest-cuda-prebuilt

--- a/.github/workflows/update-docker-manifest.yaml
+++ b/.github/workflows/update-docker-manifest.yaml
@@ -38,9 +38,9 @@ jobs:
           rosdistro: galactic
           tag-name: latest-cuda
 
-      - name: Create alias from 'autoware-universe:{rosdistro}-latest-cuda-prebuilt' to 'autoware-universe:latest-cuda-prebuilt'
+      - name: Create alias from 'autoware-universe:{rosdistro}-latest-prebuilt-cuda' to 'autoware-universe:latest-prebuilt-cuda'
         uses: ./.github/actions/create-main-distro-alias
         with:
           package-name: autoware-universe
           rosdistro: galactic
-          tag-name: latest-cuda-prebuilt
+          tag-name: latest-prebuilt-cuda


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

Currently, the only alias is from {rosdistro}-latest' to 'autoware-universe:latest'

This PR adds other aliases.
- {rosdistro}-latest-prebuilt' to 'autoware-universe:latest-prebuilt'
- {rosdistro}-latest-cuda' to 'autoware-universe:latest-cuda'
- {rosdistro}-latest-cuda-prebuilt' to 'autoware-universe:latest-cuda-prebuilt'

Related: #335
Depends on: #354 (Changing prefix to suffix)

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
