### PR TITLE
ci: remove duplicates in CI scripts

### DIFF
--- a/.github/workflows/build-humble-self-hosted.yaml
+++ b/.github/workflows/build-humble-self-hosted.yaml
@@ -17,7 +17,12 @@ jobs:
 
       - name: Run setup script
         run: |
-          ./setup-dev-env.sh -y universe
+          ./setup-dev-env.sh -y
+
+      - name: Set git config
+        uses: autowarefoundation/autoware-github-actions/set-git-config@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run vcs import
         run: |

--- a/.github/workflows/build-main-self-hosted.yaml
+++ b/.github/workflows/build-main-self-hosted.yaml
@@ -17,7 +17,12 @@ jobs:
 
       - name: Run setup script
         run: |
-          ./setup-dev-env.sh -y universe
+          ./setup-dev-env.sh -y
+
+      - name: Set git config
+        uses: autowarefoundation/autoware-github-actions/set-git-config@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run vcs import
         run: |

--- a/.github/workflows/docker-build-and-push-humble.yaml
+++ b/.github/workflows/docker-build-and-push-humble.yaml
@@ -21,6 +21,11 @@ jobs:
           - { name: no-cuda, setup-args: --no-nvidia, additional-tag-suffix: "" }
           - { name: cuda, setup-args: --no-cuda-drivers, additional-tag-suffix: -cuda }
     steps:
+      # https://github.com/actions/checkout/issues/211
+      - name: Change permission of workspace
+        run: |
+          sudo chown -R $USER:$USER ${{ github.workspace }}
+
       - name: Check out repository
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/docker-build-and-push-main.yaml
+++ b/.github/workflows/docker-build-and-push-main.yaml
@@ -21,6 +21,11 @@ jobs:
           - { name: no-cuda, setup-args: --no-nvidia, additional-tag-suffix: "" }
           - { name: cuda, setup-args: --no-cuda-drivers, additional-tag-suffix: -cuda }
     steps:
+      # https://github.com/actions/checkout/issues/211
+      - name: Change permission of workspace
+        run: |
+          sudo chown -R $USER:$USER ${{ github.workspace }}
+
       - name: Check out repository
         uses: actions/checkout@v3
         with:


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

Currently, there are many duplicates in CI scripts, which has high maintenance costs.
I'd like to improve it by using [Reusable Workflows](https://docs.github.com/ja/actions/using-workflows/reusing-workflows).

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
