### PR TITLE
feat: add ament_cmake fork

### DIFF
--- a/autoware.repos
+++ b/autoware.repos
@@ -16,6 +16,10 @@ repositories:
     type: git
     url: https://github.com/autowarefoundation/autoware.core.git
     version: main
+  ros2/ament_cmake:
+    type: git
+    url: https://github.com/autowarefoundation/ament_cmake.git
+    version: autoware-humble
   # universe
   universe/autoware.universe:
     type: git


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
This PR adds [ament_cmake fork](https://github.com/autowarefoundation/ament_cmake.git) of autoware to the repository.

It contains only the `ament_cmake_auto` package with [this PR](https://github.com/ament/ament_cmake/pull/385) cherry picked on it.

Follow up from:
- https://github.com/autowarefoundation/autoware_common/pull/76

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
