### PR TITLE
chore: remove topic tools from repos

### DIFF
--- a/autoware.repos
+++ b/autoware.repos
@@ -45,10 +45,6 @@ repositories:
     type: git
     url: https://github.com/tier4/pointcloud_to_laserscan.git
     version: tier4/main
-  universe/vendor/topic_tools:
-    type: git
-    url: https://github.com/tier4/topic_tools.git
-    version: tier4/main
   # launcher
   launcher/autoware_launch:
     type: git


### PR DESCRIPTION
## Description

`topic_tools` is now available from the apt repository. (The upstream repositroy is https://github.com/ros-tooling/topic_tools.)
I remove the tier4 fork of legacy `topic_tools`, and will fix some launch files which include `topic_tools`.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
