### PR TITLE
fix(repos): add the latest hash of ros/diagnostics

### DIFF
--- a/autoware.repos
+++ b/autoware.repos
@@ -82,3 +82,8 @@ repositories:
     type: git
     url: https://github.com/autowarefoundation/autoware_individual_params.git
     version: main
+  # external
+  external/ros/diagnostics:
+    type: git
+    url: https://github.com/ros/diagnostics.git
+    version: 31343dbbb8c2d1380768ed101a9d32f2df6aaee1

--- a/autoware.repos
+++ b/autoware.repos
@@ -16,6 +16,10 @@ repositories:
     type: git
     url: https://github.com/tier4/autoware_auto_msgs.git
     version: tier4/main
+  core/external/diagnostics:
+    type: git
+    url: https://github.com/ros/diagnostics.git
+    version: 31343dbbb8c2d1380768ed101a9d32f2df6aaee1
   # universe
   universe/autoware.universe:
     type: git
@@ -82,8 +86,3 @@ repositories:
     type: git
     url: https://github.com/autowarefoundation/autoware_individual_params.git
     version: main
-  # external
-  external/ros/diagnostics:
-    type: git
-    url: https://github.com/ros/diagnostics.git
-    version: 31343dbbb8c2d1380768ed101a9d32f2df6aaee1


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

As described in https://github.com/ros/diagnostics/issues/229, the latest code of `ros/diagnostics` isn't released yet, which includes some important bug fixes.

![image](https://user-images.githubusercontent.com/31987104/172500273-b56d7056-e76c-47eb-865e-061ae6097bc4.png)

For that, I'd like to add the source dependency.

Note: I'll wait for #374 (cleanup of `autoware.repos`) to be merged.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
